### PR TITLE
Fix typo in `oriented_lattice\bmatrix.m`

### DIFF
--- a/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
+++ b/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
@@ -33,4 +33,4 @@ function [b, arlu, angrlu] = bmatrix(obj)
 
 angdeg = obj.angdeg;
 alatt  = obj.alatt;
-[b,arly,angrlu] = bmatrix(angder,alatt);
+[b,arly,angrlu] = bmatrix(angdeg,alatt);


### PR DESCRIPTION
Change `angder` -> `angdeg` as required. This was causing test failures.