### PR TITLE
Fix @oriented_lattice/bmatrix typo `arly`->`arlu`

### DIFF
--- a/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
+++ b/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
@@ -33,4 +33,4 @@ function [b, arlu, angrlu] = bmatrix(obj)
 
 angdeg = obj.angdeg;
 alatt  = obj.alatt;
-[b,arly,angrlu] = bmatrix(angdeg,alatt);
+[b, arlu, angrlu] = bmatrix(angdeg, alatt);


### PR DESCRIPTION
The second return value in `bmatrix` was not being set correctly due to a typo.