### PR TITLE
Introduce 'CapSize' to custom_errorbars

### DIFF
--- a/herbert_core/graphics/@IX_dataset_1d/private/custom_errorbars.m
+++ b/herbert_core/graphics/@IX_dataset_1d/private/custom_errorbars.m
@@ -15,9 +15,9 @@ if verLessThan('matlab','8.4')
     xd(4:9:end)=xd(1:9:end);xd(5:9:end)=xd(1:9:end);
     xd(7:9:end)=xd(1:9:end);xd(8:9:end)=xd(1:9:end);
     set(c(2),'XData',xd)
-else
+elseif verLessThan('matlab',9.1)
     % TODO! Should be better way of doing this, but it is currently unclear
-    % how to set errorbar cap lengths to zero for Matlab V>=2014b in any
+    % how to set errorbar cap lengths to zero for Matlab 2016b>V>=2014b in any
     % other way.
     h=plot(x,signal,'Color',color,...
         'LineStyle',linestyle,'LineWidth',linewidth,...
@@ -40,5 +40,9 @@ else
     if ~hold_state
         hold 'off'
     end
+else
+    % Optional named value 'CapSize' introduced in MATLAB 2016b (v9.1)
+    h = errorbar(x,signal,error,'Color',color,'LineStyle',linestyle,...
+            'Marker',marker_type,'MarkerSize',marker_size,'CapSize',0);
 end
 


### PR DESCRIPTION
The errorbar cap length was introduced as an optional named value 'CapSize', with units in points, in MATLAB 2016b.
Setting the cap length to zero has the effect that very-short errorbars (compared to the vertical axis) are not drawn, compared to the old method of drawing the symbols and errorbars separately which draws a dot in the same situation.

This function can be simplified if the minimum version of MATLAB supported by Herbert is ever increased to 2016b. (Efficient use of Euphonic and/or brille by Horace requires support for Python `memoryview` objects, which was introduced in MATLAB 2018b.)