### PR TITLE
Add post build commands for mex libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # Look for packages early so we can exit if they're not found
 find_package(MPI REQUIRED)
 include(herbert_FindMatlab)
+include(herbert_AddMex)
 if(${BUILD_TESTS})
   include(herbert_FindGTest)
   enable_testing()

--- a/_LowLevelCode/CPP/cpp_communicator/CMakeLists.txt
+++ b/_LowLevelCode/CPP/cpp_communicator/CMakeLists.txt
@@ -11,7 +11,7 @@ set(HDR_FILES
 )
 
 set(MEX_NAME "cpp_communicator")
-matlab_add_mex(
+herbert_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
 )

--- a/_LowLevelCode/CPP/get_ascii_file/CMakeLists.txt
+++ b/_LowLevelCode/CPP/get_ascii_file/CMakeLists.txt
@@ -8,7 +8,7 @@ set(HDR_FILES
 )
 
 set(MEX_NAME "get_ascii_file")
-matlab_add_mex(
+herbert_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
 )

--- a/_LowLevelCode/Fortran/source_mex/CMakeLists.txt
+++ b/_LowLevelCode/Fortran/source_mex/CMakeLists.txt
@@ -23,7 +23,7 @@ set(FILE_NAMES
 foreach(_file_name ${FILE_NAMES})
     string(REPLACE "_fortran" "" _base_name ${_file_name})
     set(_mex_name "${_base_name}_mex")
-    matlab_add_mex(
+    herbert_add_mex(
         NAME "${_mex_name}"
         SRC "${_file_name}.F"
     )

--- a/cmake/herbert_AddMex.cmake
+++ b/cmake/herbert_AddMex.cmake
@@ -1,0 +1,43 @@
+function(herbert_add_mex)
+
+    # Parse the arguments
+    set(prefix "MEX")
+    set(noValues "EXECUTABLE" "MODULE" "SHARED")
+    set(singleValues "NAME" "OUTPUT_NAME" "DOCUMENTATION")
+    set(multiValues "SRC" "LINK_TO")
+    cmake_parse_arguments(
+        "${prefix}"
+        "${noValues}"
+        "${singleValues}"
+        "${multiValues}"
+        ${ARGN}
+    )
+
+    if(${${prefix}_EXECUTABLE})
+        set(TYPE EXECUTABLE)
+    elseif(${${prefix}_MODULE})
+        set(TYPE MODULE)
+    elseif(${${prefix}_MODULE})
+        set(TYPE SHARED)
+    endif()
+
+    set(HERBERT_DLL_DIR "${CMAKE_SOURCE_DIR}/herbert_core/DLL")
+
+    matlab_add_mex(
+        NAME "${${prefix}_NAME}"
+        "${TYPE}"
+        SRC "${${prefix}_SRC}"
+        OUTPUT_NAME "${${prefix}_OUTPUT_NAME}"
+        DOCUMENTATION "${${prefix}_DOCUMENTATION}"
+        LINK_TO "${${prefix}_LINK_TO}"
+    )
+
+    set(_target_file "$<TARGET_FILE:${${prefix}_NAME}>")
+    set(_dest_file "${HERBERT_DLL_DIR}/$<TARGET_FILE_NAME:${${prefix}_NAME}>")
+    add_custom_command(TARGET "${${prefix}_NAME}"
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${_target_file}" "${_dest_file}"
+        COMMENT "Copying ${${prefix}_NAME}.${Matlab_MEX_EXTENSION} into ${HERBERT_DLL_DIR}"
+    )
+
+endfunction()

--- a/cmake/herbert_AddMex.cmake
+++ b/cmake/herbert_AddMex.cmake
@@ -1,9 +1,64 @@
+#[=======================================================================[.rst:
+herbert_add_mex
+--------------------
+
+Build a Matlab mex library. Most arguments are passed to the `matlab_add_mex`
+function defined in the `FindMatlab.cmake` script bundled with CMake. Due to
+this, the `FindMatlab.cmake` script must be called before this script is this
+function is defined.
+
+::
+
+    herbert_add_mex(
+        NAME <name>
+        [EXECUTABLE | MODULE | SHARED]
+        SRC src1 [src2 ...]
+        [OUTPUT_NAME output_name]
+        [DOCUMENTATION file.txt]
+        [LINK_TO target1 target2 ...]
+        [COPY_TO directory]
+        [...]
+    )
+
+Arguments
+^^^^^^^^^
+
+From the FindMatlab.cmake script:
+
+``NAME``
+name of the target.
+``SRC``
+list of source files.
+``LINK_TO``
+a list of additional link dependencies.  The target links to ``libmex``
+by default. If ``Matlab_MX_LIBRARY`` is defined, it also
+links to ``libmx``.
+``OUTPUT_NAME``
+if given, overrides the default name. The default name is
+the name of the target without any prefix and
+with ``Matlab_MEX_EXTENSION`` suffix.
+``DOCUMENTATION``
+if given, the file ``file.txt`` will be considered as
+being the documentation file for the MEX file. This file is copied into
+the same folder without any processing, with the same name as the final
+mex file, and with extension `.m`. In that case, typing ``help <name>``
+in Matlab prints the documentation contained in this file.
+``MODULE`` or ``SHARED`` may be given to specify the type of library to be
+created. ``EXECUTABLE`` may be given to create an executable instead of
+a library. If no type is given explicitly, the type is ``SHARED``.
+
+Additional:
+
+``COPY_TO``
+The directory to copy the mex library into after compilation.
+
+#]=======================================================================]
 function(herbert_add_mex)
 
     # Parse the arguments
     set(prefix "MEX")
     set(noValues "EXECUTABLE" "MODULE" "SHARED")
-    set(singleValues "NAME" "OUTPUT_NAME" "DOCUMENTATION")
+    set(singleValues "NAME" "OUTPUT_NAME" "DOCUMENTATION" "COPY_TO")
     set(multiValues "SRC" "LINK_TO")
     cmake_parse_arguments(
         "${prefix}"
@@ -14,14 +69,16 @@ function(herbert_add_mex)
     )
 
     if(${${prefix}_EXECUTABLE})
-        set(TYPE EXECUTABLE)
+        set(TYPE "EXECUTABLE")
     elseif(${${prefix}_MODULE})
-        set(TYPE MODULE)
-    elseif(${${prefix}_MODULE})
-        set(TYPE SHARED)
+        set(TYPE "MODULE")
+    elseif(${${prefix}_SHARED})
+        set(TYPE "SHARED")
     endif()
 
-    set(HERBERT_DLL_DIR "${CMAKE_SOURCE_DIR}/herbert_core/DLL")
+    if(NOT ${prefix}_COPY_TO)
+        set(${prefix}_COPY_TO "${CMAKE_SOURCE_DIR}/herbert_core/DLL")
+    endif()
 
     matlab_add_mex(
         NAME "${${prefix}_NAME}"
@@ -33,11 +90,11 @@ function(herbert_add_mex)
     )
 
     set(_target_file "$<TARGET_FILE:${${prefix}_NAME}>")
-    set(_dest_file "${HERBERT_DLL_DIR}/$<TARGET_FILE_NAME:${${prefix}_NAME}>")
+    set(_dest_file "${${prefix}_COPY_TO}/$<TARGET_FILE_NAME:${${prefix}_NAME}>")
     add_custom_command(TARGET "${${prefix}_NAME}"
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "${_target_file}" "${_dest_file}"
-        COMMENT "Copying ${${prefix}_NAME}.${Matlab_MEX_EXTENSION} into ${HERBERT_DLL_DIR}"
+        COMMENT "Copying ${${prefix}_NAME}.${Matlab_MEX_EXTENSION} into ${${prefix}_COPY_TO}"
     )
 
 endfunction()


### PR DESCRIPTION
This PR writes a `herbert_add_mex` function in CMake. This function basically does the same thing as CMake's built-in `matlab_add_mex` except it will copy the mex library to a given location after compilation. The default copy location is `herbert_core/DLL`