### PR TITLE
Fix config error when unit tests are not available

### DIFF
--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -10,11 +10,13 @@ if isempty(rootpath)
 end
 tests_path = fullfile(rootpath,'_test');
 if ~(exist(tests_path,'dir')==7)
-    warning('HERBERT_INIT:invalid_setup',...
-        'Can not set-up access to the unit tests as no unint tests at %s are available',...
-        test_path);
-    tests_path = '';
-    return;
+    if init
+        warning('HERBERT_INIT:invalid_setup',...
+            'Can not set-up access to the unit tests as no unint tests at %s are available',...
+            tests_path);
+        tests_path = '';
+        return;
+    end
 end
 system_admin = fullfile(rootpath,'admin');
 xunit_path= fullfile(tests_path,'matlab_xunit','xunit');  % path for unit tests harness

--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -15,8 +15,8 @@ if ~(exist(tests_path,'dir')==7)
             'Can not set-up access to the unit tests as no unint tests at %s are available',...
             tests_path);
         tests_path = '';
-        return;
     end
+    return;
 end
 system_admin = fullfile(rootpath,'admin');
 xunit_path= fullfile(tests_path,'matlab_xunit','xunit');  % path for unit tests harness

--- a/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
+++ b/herbert_core/configuration/@herbert_config/private/process_unit_test_path.m
@@ -14,8 +14,8 @@ if ~(exist(tests_path,'dir')==7)
         warning('HERBERT_INIT:invalid_setup',...
             'Can not set-up access to the unit tests as no unint tests at %s are available',...
             tests_path);
-        tests_path = '';
     end
+    tests_path = '';
     return;
 end
 system_admin = fullfile(rootpath,'admin');


### PR DESCRIPTION
Fix typo that was throwing an error instead of a warning - `test_path` → `tests_path`. 

Running `init_herbert.m` using the new package was throwing an error since the package does not contain the `_test` directory. This was caused by a typo. 

Add qualifier so that the warning will only be shown if a user is attempting to initialize the tests and the directory does not exist. Previously the warning/error was shown every time the package was started