### PR TITLE
Increase allowed CTest ouput size

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -67,7 +67,10 @@ pipeline {
 
         stage('Package') {
             steps {
-                sh './tools/build_config/build.sh --package'
+                sh '''
+                    module load cmake/\$CMAKE_VERSION &&
+                    ./tools/build_config/build.sh --package'
+                '''
 
                 // Archive the release package
                 archiveArtifacts(

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
             steps {
                 sh '''
                     module load cmake/\$CMAKE_VERSION &&
-                    ./tools/build_config/build.sh --package'
+                    ./tools/build_config/build.sh --package
                 '''
 
                 // Archive the release package

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -12,6 +12,7 @@ readonly HERBERT_ROOT="$(realpath $(dirname "$0")/../..)"
 # matlab executable. The Matlab on the path will likely be a symlink so we need
 # to resolve it with `readlink`
 readonly MATLAB_ROOT="$(realpath $(dirname $(readlink -f $(which matlab)))/..)"
+readonly MAX_CTEST_SUCCESS_OUTPUT_LENGTH="4096" # bytes
 
 function echo_and_run {
   echo "+ $1"
@@ -62,7 +63,9 @@ function run_tests() {
 
   echo -e "\nRunning test step..."
   echo_and_run "cd ${build_dir}"
-  test_cmd="ctest -T Test --no-compress-output --output-on-failure"
+  test_cmd="ctest -T Test --no-compress-output"
+  test_cmd+=" --output-on-failure"
+  test_cmd+=" --test-output-size-passed ${MAX_CTEST_SUCCESS_OUTPUT_LENGTH}"
   echo_and_run "${test_cmd}"
 }
 


### PR DESCRIPTION
Increase the allowed size of the CTest results xml for tests that pass (tests that fail are automatically not truncated).