### PR TITLE
Pacakge _test directory with Herbert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,13 +42,21 @@ add_subdirectory("admin")
 # Install commands
 # =============================================================================
 include(herbert_CPackConfig)
-install(
-    DIRECTORY "herbert_core/"
-    DESTINATION "Herbert"
-    USE_SOURCE_PERMISSIONS
-    PATTERN "*.m~" EXCLUDE
-    PATTERN "*.asv" EXCLUDE
+set(TOP_LEVEL_INSTALL_DIRS  # List of directories for top level of install dir
+    "admin"
+    "herbert_core"
+    "_test"
 )
+foreach(_dir ${TOP_LEVEL_INSTALL_DIRS})
+    install(
+        DIRECTORY "${_dir}"
+        DESTINATION "Herbert"
+        USE_SOURCE_PERMISSIONS
+        PATTERN "*.m~" EXCLUDE
+        PATTERN "*.asv" EXCLUDE
+    )
+endforeach()
+
 install(
     FILES "LICENSE" "README.md"
     DESTINATION "."


### PR DESCRIPTION
The reason for this comes mostly from Jenkins+Horace. Horace pulls the
Herbert build package when it runs its tests, however the testing
framework is in Herbert! Hence the test framework needs to be present in
Herbert - at least for the time being.

Ideally we would not package the _test directory at all and Horace's
tests should all be written using the new Matlab test framework. This is
probably not possible, however we should find a way to minimise the size
of the Herbert package we ship to users, but still allowing Horace to
perform its full set of tests etc.
