### PR TITLE
Stop application_off removing paths twice

### DIFF
--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -128,10 +128,6 @@ for i=1:numel(application_init_old)
             disp(['Function ',app_name,'_off.m not found in ',rootpath])
             disp('Clearing rootpath and subdirectories from Matlab path in any case')
         end
-        paths = genpath(rootpath);
-        warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
-        rmpath(paths);
-        warning(warn_state);    % return warnings to initial state
         cd(start_dir)           % return to starting directory
     catch ME
         cd(start_dir)           % return to starting directory

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -130,7 +130,6 @@ for i=1:numel(application_init_old)
             paths = genpath(rootpath);
             warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
             rmpath(paths);
-            addpath(getenv('MATLABPATH'));
             warning(warn_state);    % return warnings to initial state
         end
         cd(start_dir)           % return to starting directory
@@ -139,4 +138,6 @@ for i=1:numel(application_init_old)
         message=ME.message;
         disp(['Problems removing ',rootpath,' and any sub-directories from matlab path. Reason: ',message]);
     end
+    % Make sure we're not removing any global paths
+    addpath(getenv('MATLABPATH'));
 end

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -130,7 +130,8 @@ for i=1:numel(application_init_old)
             paths = genpath(rootpath);
             warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
             rmpath(paths);
-            warning(warn_state);    % return warnings to initial state            
+            addpath(getenv('MATLABPATH'));
+            warning(warn_state);    % return warnings to initial state
         end
         cd(start_dir)           % return to starting directory
     catch ME

--- a/herbert_core/herbert_init.m
+++ b/herbert_core/herbert_init.m
@@ -127,6 +127,10 @@ for i=1:numel(application_init_old)
         else
             disp(['Function ',app_name,'_off.m not found in ',rootpath])
             disp('Clearing rootpath and subdirectories from Matlab path in any case')
+            paths = genpath(rootpath);
+            warn_state=warning('off','all');    % turn of warnings (so don't get errors if remove non-existent paths)
+            rmpath(paths);
+            warning(warn_state);    % return warnings to initial state            
         end
         cd(start_dir)           % return to starting directory
     catch ME

--- a/herbert_core/herbert_off.m
+++ b/herbert_core/herbert_off.m
@@ -16,14 +16,11 @@ rootpath = fileparts(fileparts(which('herbert_init')));
 warn_state=warning('off','all');
 try
     paths = genpath(rootpath);
-    % Make sure we're not removing any global paths
-    global_paths = split(getenv('MATLABPATH'), ':');
-    for i = 1:numel(global_paths)
-        paths = strrep(paths, global_paths{i}, '');
-    end
     rmpath(paths);
     warning(warn_state);  % return warnings to initial state
 catch
     warning(warn_state);  % return warnings to initial state if error encountered
     error('Problems removing "%s" and sub-directories from Matlab path',rootpath)
 end
+% Make sure we're not removing any global paths
+addpath(getenv('MATLABPATH'));


### PR DESCRIPTION
The function `application_off` was calling `herbert_off` which removed all paths beneath Herebert's root - except for those in the MATLABPATH environment variable. `application_off` then removed the paths AGAIN, this time also removing the paths in MATLABPATH - which we do not want.