### PR TITLE
Move herbert_init call inside CTest test script

### DIFF
--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -19,6 +19,7 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
             "try;\
+                herbert_init;\
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\
                 disp('Error caught attempting to run test:');\
@@ -26,7 +27,6 @@ foreach(_test_dir ${TEST_DIRECTORIES})
                 exit(1);\
             end;\
             exit(~res)"
-        UNITTEST_PRECOMMAND "herbert_init"
         ADDITIONAL_PATH
             "${CMAKE_SOURCE_DIR}/admin"
             "${CMAKE_SOURCE_DIR}/herbert_core"

--- a/herbert_core/admin/@opt_config_manager/OptimalConfigInfo.xml
+++ b/herbert_core/admin/@opt_config_manager/OptimalConfigInfo.xml
@@ -258,7 +258,7 @@
       <parallel_config>
          <worker>worker_v2</worker>
          <parallel_framework>mpiexec_mpi</parallel_framework>
-         <cluster_config>default</cluster_config>
+         <cluster_config>local</cluster_config>
          <shared_folder_on_local/>
          <shared_folder_on_remote/>
          <working_directory/>


### PR DESCRIPTION
The `herbert_init` call was previously registered as a pre-command in the `matlab_add_unit_test` function. For some reason, if herbert_init failed then the test would terminate, but no error would be raised.

Moving the `herbert_init` call inside the `try-catch` block within the test script run by CTest fixes this.

Fixes #63 