### PR TITLE
Windows nightly packages name correction

### DIFF
--- a/cmake/herbert_FindMatlab.cmake
+++ b/cmake/herbert_FindMatlab.cmake
@@ -27,7 +27,15 @@ module. You'll find the file bundled with your CMake installation.
 find_package(Matlab REQUIRED COMPONENTS MAIN_PROGRAM MEX_COMPILER)
 get_filename_component(Matlab_LIBRARY_DIR "${Matlab_MEX_LIBRARY}" DIRECTORY)
 get_filename_component(Matlab_BIN_DIR "${Matlab_MAIN_PROGRAM}" DIRECTORY)
-get_filename_component(Matlab_VERSION "${Matlab_ROOT_DIR}" NAME)
+
+# Get the Matlab release from the VersionInfo.xml file
+file(READ "${Matlab_ROOT_DIR}/VersionInfo.xml" _version_info)
+string(REGEX REPLACE
+    ".*<release>(R[0-9]+[ab])</release>.*"
+    "\\1"
+    Matlab_VERSION
+    "${_version_info}"
+)
 
 # Find the libut library
 find_library(Matlab_UT_LIBRARY

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
           else {
             powershell '''
               ./tools/build_config/build.ps1 -print_versions -build \
-                  -cmake_flags "-DHerbert_RELEASE_TYPE=$RELEASE_TYPE"
+                  -cmake_flags "-DHerbert_RELEASE_TYPE=\$env:RELEASE_TYPE"
             '''
           }
         }


### PR DESCRIPTION
This solves the issue of the Windows nightly packages not being named correctly.

Fixes #72 