### PR TITLE
Shellcheck updates

### DIFF
--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -7,11 +7,11 @@ readonly FALSE=0
 readonly TRUE=1
 readonly CMAKE_GENERATOR="Unix Makefiles"
 # The Herbert root directory is two levels above this script
-readonly HERBERT_ROOT="$(realpath $(dirname "$0")/../..)"
+readonly HERBERT_ROOT="$(realpath "$(dirname "$0")"/../..)"
 # The Matlab root directory is one level above Matlab/bin which contains the
 # matlab executable. The Matlab on the path will likely be a symlink so we need
 # to resolve it with `readlink`
-readonly MATLAB_ROOT=$(realpath "$(dirname $(readlink -f $(command -v matlab)))"/..)
+readonly MATLAB_ROOT="$(realpath "$(dirname "$(readlink -f "$(command -v matlab)")")"/..)"
 readonly MAX_CTEST_SUCCESS_OUTPUT_LENGTH="10000" # 10kB
 
 function echo_and_run {
@@ -99,7 +99,7 @@ function main() {
         # options
         -X|--build_tests) build_tests="$2"; shift; shift ;;
         -C|--build_config) build_config="$2"; shift; shift ;;
-        -O|--build_dir) build_dir="$(realpath $2)"; shift; shift ;;
+        -O|--build_dir) build_dir="$(realpath "$2")"; shift; shift ;;
         -f|--build_fortran) build_fortran="$2"; shift; shift ;;
         -B|--cmake_flags) cmake_flags="$2"; shift; shift ;;
 	*) echo "Unrecognised argument '$key'"; exit 1 ;;
@@ -114,12 +114,12 @@ function main() {
     warning_msg="Warning: Build directory ${build_dir} already exists.\n\
         This may not be a clean build."
     echo_and_run "mkdir ${build_dir}" || warning "${warning_msg}"
-    run_configure ${build_dir} ${build_config} ${build_tests} ${cmake_flags}
-    run_build ${build_dir}
+    run_configure "${build_dir}" "${build_config}" "${build_tests}" "${cmake_flags}"
+    run_build "${build_dir}"
   fi
 
   if ((${test})); then
-    run_tests ${build_dir}
+    run_tests "${build_dir}"
   fi
 
   if ((${package})); then

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -11,7 +11,7 @@ readonly HERBERT_ROOT="$(realpath $(dirname "$0")/../..)"
 # The Matlab root directory is one level above Matlab/bin which contains the
 # matlab executable. The Matlab on the path will likely be a symlink so we need
 # to resolve it with `readlink`
-readonly MATLAB_ROOT="$(realpath $(dirname $(readlink -f $(which matlab)))/..)"
+readonly MATLAB_ROOT=$(realpath "$(dirname $(readlink -f $(command -v matlab)))"/..)
 readonly MAX_CTEST_SUCCESS_OUTPUT_LENGTH="10000" # 10kB
 
 function echo_and_run {
@@ -24,10 +24,10 @@ function warning {
 }
 
 function print_package_versions() {
-  echo "$(cmake --version | head -n 1)"
+  cmake --version | head -n 1
   echo "Matlab: ${MATLAB_ROOT}"
-  echo "$(g++ --version | head -n 1)"
-  echo "$(gfortran --version | head -n 1)"
+  g++ --version | head -n 1
+  gfortran --version | head -n 1
   echo
 }
 

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -102,6 +102,7 @@ function main() {
         -O|--build_dir) build_dir="$(realpath $2)"; shift; shift ;;
         -f|--build_fortran) build_fortran="$2"; shift; shift ;;
         -B|--cmake_flags) cmake_flags="$2"; shift; shift ;;
+	*) echo "Unrecognised argument '$key'"; exit 1 ;;
     esac
   done
 

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -106,11 +106,11 @@ function main() {
     esac
   done
 
-  if ((${print_versions})); then
+  if ((print_versions)); then
     print_package_versions
   fi
 
-  if ((${build})); then
+  if ((build)); then
     warning_msg="Warning: Build directory ${build_dir} already exists.\n\
         This may not be a clean build."
     echo_and_run "mkdir ${build_dir}" || warning "${warning_msg}"
@@ -118,11 +118,11 @@ function main() {
     run_build "${build_dir}"
   fi
 
-  if ((${test})); then
+  if ((test)); then
     run_tests "${build_dir}"
   fi
 
-  if ((${package})); then
+  if ((package)); then
     run_package
   fi
 }


### PR DESCRIPTION
Ran the build.sh script through ShellCheck (https://github.com/koalaman/shellcheck).

These changes were suggested by the script rules.

Added default in the case block to catch invalid arguments and prevent script hanging in the while loop.