### PR TITLE
Exit PowerShell build script early on invalid input

### DIFF
--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -1,15 +1,32 @@
 param (
-  [int]$vs_version = 2017,
-  [string]$build_config = 'Release',
-  [string]$build_dir = "",
-  [string]$build_tests = "On",
-  [string]$cmake_flags = "",
-  [string]$build_fortran = "OFF",
+  [switch][Alias("b")]$build,
+  [switch][Alias("t")]$test,
+  [switch][Alias("p")]$package,
+  [switch][Alias("v")]$print_versions,
 
-  [switch]$build,
-  [switch]$test,
-  [switch]$package,
-  [switch]$print_versions
+  [int][ValidateSet(2015, 2017, 2019)]
+  [Alias("VS")]
+  $vs_version = 2017,
+
+  [string][ValidateSet("ON", "OFF")]
+  [Alias("X")]
+  $build_tests = "ON",
+
+  [string][ValidateSet("Release", "Debug")]
+  [Alias("C")]
+  $build_config = 'Release',
+
+  [string]
+  [Alias("O")]
+  $build_dir = "",
+
+  [string][ValidateSet("ON", "OFF")]
+  [Alias("N")]
+  $build_fortran = "OFF",
+
+  [string]
+  [Alias("F")]
+  $cmake_flags = ""
 )
 
 if ($args) {

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -12,6 +12,14 @@ param (
   [switch]$print_versions
 )
 
+if ($args) {
+  $error_msg = "Unrecognised argument(s):"
+  foreach($arg in $args) {
+    $error_msg += "`n    $arg"
+  }
+  throw "$error_msg"
+}
+
 # Mapping from year to Visual Studio version
 $VS_VERSION_MAP = @{
   2015 = 'Visual Studio 14 2015';

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -100,8 +100,8 @@ function main() {
         -X|--build_tests) build_tests="$2"; shift; shift ;;
         -C|--build_config) build_config="$2"; shift; shift ;;
         -O|--build_dir) build_dir="$(realpath "$2")"; shift; shift ;;
-        -f|--build_fortran) build_fortran="$2"; shift; shift ;;
-        -B|--cmake_flags) cmake_flags="$2"; shift; shift ;;
+        -N|--build_fortran) build_fortran="$2"; shift; shift ;;
+        -F|--cmake_flags) cmake_flags="$2"; shift; shift ;;
         *) echo "Unrecognised argument '$key'"; exit 1 ;;
     esac
   done

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -102,7 +102,7 @@ function main() {
         -O|--build_dir) build_dir="$(realpath "$2")"; shift; shift ;;
         -f|--build_fortran) build_fortran="$2"; shift; shift ;;
         -B|--cmake_flags) cmake_flags="$2"; shift; shift ;;
-	*) echo "Unrecognised argument '$key'"; exit 1 ;;
+        *) echo "Unrecognised argument '$key'"; exit 1 ;;
     esac
   done
 


### PR DESCRIPTION
This prevents potentially long processes running if the user has made a typo in some script argument. This also mirrors the behaviour in the bash build script.