### PR TITLE
Set TMP environment variable in Jenkinsfile

### DIFF
--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -29,34 +29,15 @@ foreach(_test_dir ${TEST_DIRECTORIES})
     matlab_add_unit_test(
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
-            "try;\
-                herbert_on;\
-                config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
-                \
-                hc = herbert_config;\
-                hc.init_tests = true;\
-                hc.use_mex = true;\
-                hc.use_mex_C = true;\
-                hc.force_mex_if_use_mex = true;\
-                \
-                pc = parallel_config;\
-                pc.shared_folder_on_local = '${CMAKE_BINARY_DIR}/tests/local';\
-                pc.shared_folder_on_remote = '${CMAKE_BINARY_DIR}/tests/remote';\
-                \
-                config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
-                disp(hc);\
-                disp(pc);\
-                \
-                res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
-            catch ME;\
-                disp('Error caught attempting to run test:');\
-                disp(ME);\
-                exit(1);\
-            end;\
-            exit(~res)"
+            "res = ctest_run_herbert_test('${CMAKE_SOURCE_DIR}/_test/${_test_dir}', \
+                'config_dir', '${CMAKE_BINARY_DIR}/tests/config', \
+                'shared_local_dir', '${CMAKE_BINARY_DIR}/tests/local', \
+                'shared_remote_dir', '${CMAKE_BINARY_DIR}/tests/remote', \
+                'parallel_working_dir', '${CMAKE_BINARY_DIR}/tests');\
+            \
+            exit(~res);"
         ADDITIONAL_PATH
-            "${CMAKE_SOURCE_DIR}/admin"
-            "${CMAKE_SOURCE_DIR}/herbert_core"
+            "${CMAKE_CURRENT_LIST_DIR}"
         TIMEOUT 300  # 5 mins
     )
     set_tests_properties("${TEST_NAME}"

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -30,6 +30,7 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
             "try;\
+                disp(tempdir);\
                 herbert_init;\
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -32,21 +32,21 @@ foreach(_test_dir ${TEST_DIRECTORIES})
             "try;\
                 herbert_on;\
                 config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
-
+                \
                 hc = herbert_config;\
                 hc.init_tests = true;\
                 hc.use_mex = true;\
                 hc.use_mex_C = true;\
                 hc.force_mex_if_use_mex = true;\
-
+                \
                 pc = parallel_config;\
                 pc.shared_folder_on_local = '${CMAKE_BINARY_DIR}/tests/local';\
                 pc.shared_folder_on_remote = '${CMAKE_BINARY_DIR}/tests/remote';\
-
+                \
                 config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
                 disp(hc);\
                 disp(pc);\
-
+                \
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\
                 disp('Error caught attempting to run test:');\

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -30,7 +30,9 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
             "try;\
-                herbert_init;\
+                herbert_on;\
+                pc = parallel_config;\
+                pc.working_directory = '${CMAKE_BINARY_DIR}/local_init';\
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\
                 disp('Error caught attempting to run test:');\

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -31,9 +31,22 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         CUSTOM_TEST_COMMAND
             "try;\
                 herbert_on;\
+                config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
+
+                hc = herbert_config;\
+                hc.init_tests = true;\
+                hc.use_mex = true;\
+                hc.use_mex_C = true;\
+                hc.force_mex_if_use_mex = true;\
+
                 pc = parallel_config;\
-                pc.working_directory = '${CMAKE_BINARY_DIR}/tests';\
+                pc.shared_folder_on_local = '${CMAKE_BINARY_DIR}/tests/local';\
+                pc.shared_folder_on_remote = '${CMAKE_BINARY_DIR}/tests/remote';\
+
+                config_store.set_config_folder('${CMAKE_BINARY_DIR}/tests');\
+                disp(hc);\
                 disp(pc);\
+
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\
                 disp('Error caught attempting to run test:');\
@@ -48,6 +61,6 @@ foreach(_test_dir ${TEST_DIRECTORIES})
     )
     set_tests_properties("${TEST_NAME}"
         PROPERTIES
-            ENVIRONMENT "MATLABPATH=${MATLAB_PATH}"
+            ENVIRONMENT "MATLABPATH=${MATLAB_PATH};TMP=${CMAKE_BINARY_DIR}/tests"
     )
 endforeach()

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -32,7 +32,8 @@ foreach(_test_dir ${TEST_DIRECTORIES})
             "try;\
                 herbert_on;\
                 pc = parallel_config;\
-                pc.working_directory = '${CMAKE_BINARY_DIR}/local_init';\
+                pc.working_directory = '${CMAKE_BINARY_DIR}/tests';\
+                disp(pc);\
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\
                 disp('Error caught attempting to run test:');\

--- a/_test/CMakeLists.txt
+++ b/_test/CMakeLists.txt
@@ -30,7 +30,6 @@ foreach(_test_dir ${TEST_DIRECTORIES})
         NAME "${TEST_NAME}"
         CUSTOM_TEST_COMMAND
             "try;\
-                disp(tempdir);\
                 herbert_init;\
                 res = runtests('${CMAKE_SOURCE_DIR}/_test/${_test_dir}');\
             catch ME;\

--- a/_test/ctest_run_herbert_test.m
+++ b/_test/ctest_run_herbert_test.m
@@ -1,0 +1,53 @@
+function result = ctest_run_herbert_test(test, varargin)
+% Execute `runtests` with the given directory
+%
+%  >> run_herbert_test(test, [kwarg1, value1, kwarg2, value2...])
+%
+% Positional parameters:
+%
+%   test  The directory/test case to pass to the `runtests` call
+%
+% Keyword parameters:
+%
+%   'config_dir'  The directory to store the herbert config file within.
+%
+%   'shared_local_dir'  The shared local directory for parallel workers
+%
+%   'shared_remote_dir'  The shared remote directory for parallel workers
+%
+%   'parallel_working_dir'  The working directory for parallel workers
+%
+
+% Parse input parameters
+ip = inputParser;
+addRequired(ip, 'test');
+addParameter(ip, 'config_dir', '');
+addParameter(ip, 'shared_local_dir', '');
+addParameter(ip, 'shared_remote_dir', '');
+addParameter(ip, 'parallel_working_dir', '');
+parse(ip, test, varargin{:});
+config_dir = ip.Results.config_dir;
+shared_local_dir = ip.Results.shared_local_dir;
+shared_remote_dir = ip.Results.shared_remote_dir;
+
+if isempty(which('herbert_init'))
+    herbert_on;
+end
+
+% Move config directory to specified location
+if config_dir
+    config_store.set_config_folder(config_dir);
+end
+config_man = opt_config_manager;
+config_man.this_pc_type = 'jenkins';
+config_man.load_configuration('-set_config', '-change_only_default');
+
+pc = parallel_config;
+if shared_local_dir
+    pc.shared_folder_on_local = shared_local_dir;
+end
+if shared_remote_dir
+    pc.shared_folder_on_remote = shared_remote_dir;
+end
+
+result = runtests(test);

--- a/_test/ctest_run_herbert_test.m
+++ b/_test/ctest_run_herbert_test.m
@@ -1,5 +1,10 @@
 function result = ctest_run_herbert_test(test, varargin)
-% Execute `runtests` with the given directory
+% Execute `runtests` with the given directory.
+%     The optional arguments in this function give the ability to run the given
+%     tests with an isolated config, i.e. the directories for storing configs
+%     and message exchanges are optionally changed. This is particularly useful
+%     on Jenkins where a node may be running multiple jobs on the same machine,
+%     these options prevent the jobs attempting to read/write to the same places.
 %
 %  >> run_herbert_test(test, [kwarg1, value1, kwarg2, value2...])
 %
@@ -29,6 +34,7 @@ parse(ip, test, varargin{:});
 config_dir = ip.Results.config_dir;
 shared_local_dir = ip.Results.shared_local_dir;
 shared_remote_dir = ip.Results.shared_remote_dir;
+parallel_working_dir = ip.Results.parallel_working_dir;
 
 if isempty(which('herbert_init'))
     herbert_on;
@@ -42,12 +48,16 @@ config_man = opt_config_manager;
 config_man.this_pc_type = 'jenkins';
 config_man.load_configuration('-set_config', '-change_only_default');
 
+% Set shared directories for parallel workers
 pc = parallel_config;
 if shared_local_dir
     pc.shared_folder_on_local = shared_local_dir;
 end
 if shared_remote_dir
     pc.shared_folder_on_remote = shared_remote_dir;
+end
+if parallel_working_dir
+    pc.working_directory = parallel_working_dir;
 end
 
 result = runtests(test);

--- a/_test/test_mpi_wrappers/test_FileBaseMPI_Framework.m
+++ b/_test/test_mpi_wrappers/test_FileBaseMPI_Framework.m
@@ -18,6 +18,7 @@ classdef test_FileBaseMPI_Framework< TestCase
             end
             this = this@TestCase(name);
             this.working_dir = tmp_dir;
+            disp(['Running test_FileBaseMPI_Framework with working_dir = ', this.working_dir])
             pc = parallel_config;
             if strcmpi(pc.parallel_framework,'herbert')
                 this.change_setup = false;

--- a/admin/CMakeLists.txt
+++ b/admin/CMakeLists.txt
@@ -10,8 +10,8 @@ set(_path_regex "[a-zA-Z0-9/\\\\_\\-\\.: ]+")
 
 file(READ "herbert_on.m.template" _herbert_on_template)
 string(REGEX REPLACE
-    "her_default_path='${_path_regex}'"
-    "her_default_path='${CMAKE_SOURCE_DIR}/herbert_core'"
+    "default_herbert_path ?= ?'${_path_regex}'"
+    "default_herbert_path = '${CMAKE_SOURCE_DIR}/herbert_core'"
     _herbert_on_script
     "${_herbert_on_template}"
 )

--- a/herbert_core/classes/MPIFramework/@MessagesFilebased/private/copy_existing_config_to_remote_.m
+++ b/herbert_core/classes/MPIFramework/@MessagesFilebased/private/copy_existing_config_to_remote_.m
@@ -1,5 +1,5 @@
 function copy_existing_config_to_remote_(current_config_f,remote_config_f)
-% copy configuration data necessary to initiate Herbert/Horace 
+% copy configuration data necessary to initiate Herbert
 % on a remote machine.
 %
 
@@ -8,5 +8,11 @@ if ~(exist(remote_config_f ,'dir' ) == 7)
 end
 
 if(~strcmp(fullfile(current_config_f), fullfile(remote_config_f)))
-    copyfile(current_config_f,remote_config_f,'f')
+    try
+        copyfile(current_config_f,remote_config_f,'f');
+    catch ME
+        disp(ME)
+        disp(ME.stack)
+        disp(ME.cause)
+    end
 end

--- a/herbert_core/classes/MPIFramework/@MessagesFilebased/private/copy_existing_config_to_remote_.m
+++ b/herbert_core/classes/MPIFramework/@MessagesFilebased/private/copy_existing_config_to_remote_.m
@@ -7,5 +7,6 @@ if ~(exist(remote_config_f ,'dir' ) == 7)
     mkdir(remote_config_f )
 end
 
-copyfile(current_config_f,remote_config_f,'f')
-
+if(~strcmp(fullfile(current_config_f), fullfile(remote_config_f)))
+    copyfile(current_config_f,remote_config_f,'f')
+end

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
   environment {
     // This variable becomes the path returned by `tempdir` in Matlab
     // It avoids any collisions between jobs when writing temporary files
-    TMP = env.WORKSPACE + '/temp'
+    TMP = "${env.WORKSPACE}/temp"
   }
 
   stages {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -52,6 +52,12 @@ pipeline {
     label env.AGENT
   }
 
+  environment {
+    // This variable becomes the path returned by `tempdir` in Matlab
+    // It avoids any collisions between jobs when writing temporary files
+    TMP = env.WORKSPACE + '/temp'
+  }
+
   stages {
 
     stage('Notify') {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
   environment {
     // This variable becomes the path returned by `tempdir` in Matlab
     // It avoids any collisions between jobs when writing temporary files
-    TMP = "${env.WORKSPACE}/temp"
+    TMP = "${env.WORKSPACE}/build/tests"
   }
 
   stages {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
               module load matlab/\$MATLAB_VERSION &&
               module load gcc/\$GCC_VERSION &&
               module load openmpi/\$OPEN_MPI_VERSION &&
-              mkdir \$TMP &&
+              mkdir -p \$TMP &&
               ./tools/build_config/build.sh --test
             '''
           }

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -100,17 +100,20 @@ pipeline {
     stage('Test') {
       steps {
         script {
+          // We create a temporary directory to write/read test files in
           if (isUnix()) {
             sh '''
               module load cmake/\$CMAKE_VERSION &&
               module load matlab/\$MATLAB_VERSION &&
               module load gcc/\$GCC_VERSION &&
               module load openmpi/\$OPEN_MPI_VERSION &&
+              mkdir \$TMP &&
               ./tools/build_config/build.sh --test
             '''
           }
           else {
             powershell '''
+              New-Item -ItemType Directory \$env:TMP -Force
               ./tools/build_config/build.ps1 -test
             '''
           }

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -45,7 +45,7 @@ $VS_VERSION_MAP = @{
 }
 # Herbert's root directory is two levels above this script
 $HERBERT_ROOT = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath '/../..')
-$MAX_CTEST_SUCCESS_OUTPUT_LENGTH = 10000 # 10kB
+$MAX_CTEST_SUCCESS_OUTPUT_LENGTH = 1000000 # 1000kB
 
 function Write-And-Invoke([string]$command) {
   Write-Output "+ $command"

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -12,7 +12,7 @@ readonly HERBERT_ROOT="$(realpath "$(dirname "$0")"/../..)"
 # matlab executable. The Matlab on the path will likely be a symlink so we need
 # to resolve it with `readlink`
 readonly MATLAB_ROOT="$(realpath "$(dirname "$(readlink -f "$(command -v matlab)")")"/..)"
-readonly MAX_CTEST_SUCCESS_OUTPUT_LENGTH="10000" # 10kB
+readonly MAX_CTEST_SUCCESS_OUTPUT_LENGTH="1000000" # 1000kB
 
 function echo_and_run {
   echo "+ $1"


### PR DESCRIPTION
This environment variable is what is returned by Matlab's `tempdir` function. This avoids an issue where different jobs running on the same machine attempt to write to the same place at the same time.

Fixes #82