### PR TITLE
Fix failing utilities test on windows

### DIFF
--- a/_test/shared/matlab_xunit_ISISextras/@TestCaseWithSave/TestCaseWithSave.m
+++ b/_test/shared/matlab_xunit_ISISextras/@TestCaseWithSave/TestCaseWithSave.m
@@ -648,7 +648,7 @@ classdef TestCaseWithSave < TestCase & oldTestCaseWithSaveInterface
             % (*** TGP 09/12/2018: this always enforces the default same name
             %  no matter how many other variables might have been previously saved.
             %  On the otherhand, this utlity routine always appears to be called
-            %  with an explicit value for var_name, so thhis code block is not
+            %  with an explicit value for var_name, so this code block is not
             %  going to be called...)
             if isempty(var_name)
                 var_name = [test_name,'_1'];

--- a/_test/test_utilities/test_obj2struct.m
+++ b/_test/test_utilities/test_obj2struct.m
@@ -75,7 +75,7 @@ classdef test_obj2struct < TestCaseWithSave
         end
 
         %--------------------------------------------------------------------------
-        function DISABLED_test_5 (self)
+        function test_5 (self)
             % Complicated structure - independent properties
             Ssub2.aa = 'kitty';
             Ssub2.bb = IX_aperture;
@@ -88,7 +88,7 @@ classdef test_obj2struct < TestCaseWithSave
 
             Sres = obj2structIndep(S);
 
-            assertEqualWithSave (self,Sres);
+            assertEqualToTolWithSave (self, Sres, 'tol', 1e-12);
 
         end
 


### PR DESCRIPTION
The test was failing on Windows Matlab R2019b due to comparing two floats without a tolerance. The difference between the numbers was of the order of 10<sup>-14</sup>. Now we compare with a tolerance.


Fixes #70 