### PR TITLE
Post build failed if jenkins build aborted

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -167,7 +167,7 @@ pipeline {
       post_github_status("success", "The build succeeded")
     }
 
-    failure {
+    unsuccessful {
       post_github_status("failure", "The build failed")
     }
 

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -28,7 +28,7 @@ param (
   [Alias("F")]
   $cmake_flags = "",
 
-  [string]
+  [string][ValidatePattern("R[0-9]{4}[ab]")]
   [Alias("M")]
   $matlab_release = ""
 )


### PR DESCRIPTION
Previously we were using the "failure" stage to post `Build failed` statuses to GitHub, however this block is not entered if the build is manually aborted. This meant that aborted jobs were stuck with the "build running" status on GitHub. The `unsuccessful` post-build step is run if the build has any status other than `success`.