### PR TITLE
Add Hall Symbol IX_sample

### DIFF
--- a/_test/test_instrument_classes/test_IX_sample.m
+++ b/_test/test_instrument_classes/test_IX_sample.m
@@ -30,17 +30,57 @@ classdef test_IX_sample < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_error_if_required_args_missing(name)
+            f = @()IX_sample([1,0,0],[0,1,0],'cuboid');
+            assertExceptionThrown(f, '')
+        end
+
+        %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_error_if_invalid_shape(name)
+            f = @()IX_sample([1,0,0],[0,1,0],'banana',[2,3,4]);
+            assertExceptionThrown(f, '')
+        end
+
+        %--------------------------------------------------------------------------
         function test_IX_sample_constructor_accepts_and_sets_hall_symbol(name)
             sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-hall_symbol', 'hsymbol');
             assertEqual(sample.hall_symbol, 'hsymbol');
         end
+
+        %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_accepts_and_sets_temperature(name)
+            sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-temperature', 1234.5);
+            assertEqual(sample.temperature, 1234.5);
+        end
+        function test_IX_sample_constructor_errors_for_non_numeric_temperature(name)
+            f = @()IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-temperature', 'string');
+            assertExceptionThrown(f, '')
+        end
+
+        %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_accepts_and_sets_name(name)
+            sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-name', 'test name');
+            assertEqual(sample.name, 'test name');
+        end
+
+        %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_accepts_and_sets_mosaic_eta(name)
+            eta = IX_mosaic(1234);
+            sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-eta', eta);
+            assertEqual(sample.eta, eta);
+        end
+        function test_IX_sample_constructorsets_sets_numeric_eta_as_mosaic(name)
+            sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-eta', 4134);
+            assertEqual(sample.eta, IX_mosaic(4134));
+        end
+
         %--------------------------------------------------------------------------
         function test_covariance (self)
             s = self.slookup;
             cov = s.func_eval(2,[2,2,1,4,3],@covariance);
             assertEqualWithSave (self,cov);            
         end
-        
+
         %--------------------------------------------------------------------------
         function test_pdf (self)
             nsamp = 1e7;

--- a/_test/test_instrument_classes/test_IX_sample.m
+++ b/_test/test_instrument_classes/test_IX_sample.m
@@ -30,6 +30,11 @@ classdef test_IX_sample < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
+        function test_IX_sample_constructor_accepts_and_sets_hall_symbol(name)
+            sample = IX_sample([1,0,0], [0,1,0], 'cuboid', [2,3,4], '-hall_symbol', 'hsymbol');
+            assertEqual(sample.hall_symbol, 'hsymbol');
+        end
+        %--------------------------------------------------------------------------
         function test_covariance (self)
             s = self.slookup;
             cov = s.func_eval(2,[2,2,1,4,3],@covariance);

--- a/herbert_core/classes/instrument_classes/instrument/@IX_sample/IX_sample.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_sample/IX_sample.m
@@ -12,6 +12,7 @@ classdef IX_sample
         % require checks against the other properties
         class_version_ = 1;
         name_ = '';
+        hall_symbol_ = '';
         single_crystal_ = true;
         xgeom_ = [1,0,0];
         ygeom_ = [0,1,0];
@@ -26,6 +27,7 @@ classdef IX_sample
     properties (Dependent)
         % Mirrors of private properties
         name
+        hall_symbol
         single_crystal
         xgeom
         ygeom
@@ -82,6 +84,8 @@ classdef IX_sample
             %   single_crystal  true if single crystal, false otherwise
             %                   Default: true (i.e. single crystal)
             %
+            %   hall_symbol     Symmetry group (e.g. '')
+            %
             % Note: any number of the arguments can given in arbitrary order
             % after leading positional arguments if they are preceded by the 
             % argument name (including abbrevioations) with a preceding hyphen e.g.
@@ -96,8 +100,8 @@ classdef IX_sample
                 obj = IX_sample.loadobj(varargin{1});
                 
             elseif nargin>0
-                namelist = {'name','single_crystal','xgeom','ygeom','shape',...
-                    'ps','eta','temperature'};
+                namelist = {'name','single_crystal','xgeom','ygeom',...
+                    'shape','ps','eta','temperature','hall_symbol'};
                 [S, present] = parse_args_namelist ({namelist,{'char','logical'}}, varargin{:});
                 
                 if present.name
@@ -119,6 +123,9 @@ classdef IX_sample
                 end
                 if present.temperature
                     obj.temperature_ = S.temperature;
+                end
+                if present.hall_symbol
+                    obj.hall_symbol_ = S.hall_symbol;
                 end
                 
                 [ok,mess] = check_xygeom (obj.xgeom_,obj.ygeom_);
@@ -155,7 +162,7 @@ classdef IX_sample
                 error('single_crystal must true or false (or 1 or 0)')
             end
         end
-        
+
         function obj=set.xgeom_(obj,val)
             if isnumeric(val) && numel(val)==3 && ~all(val==0)
                 obj.xgeom_=val(:)';
@@ -163,7 +170,7 @@ classdef IX_sample
                 error('''xgeom'' must be a three-vector')
             end
         end
-        
+
         function obj=set.ygeom_(obj,val)
             if isnumeric(val) && numel(val)==3 && ~all(val==0)
                 obj.ygeom_=val(:)';
@@ -171,7 +178,7 @@ classdef IX_sample
                 error('''ygeom'' must be a three-vector')
             end
         end
-        
+
         function obj=set.shape_(obj,val)
             if is_string(val) && ~isempty(val)
                 [ok,mess,fullname] = obj.shapes_.valid(val);
@@ -184,7 +191,7 @@ classdef IX_sample
                 error('Sample shape must be a non-empty character string')
             end
         end
-        
+
         function obj=set.ps_(obj,val)
             if isnumeric(val) && (isempty(val) || isvector(val))
                 if isempty(val)
@@ -214,7 +221,14 @@ classdef IX_sample
                 error('Temperature must be numeric scalar greater than or equal to zero')
             end
         end
-        
+
+        function obj=set.hall_symbol_(obj,val)
+            if is_string(val)
+                obj.hall_symbol_=val;
+            else
+                error('Sample Hall symbol must be a character string (or empty string)')
+            end
+        end
         %------------------------------------------------------------------
         % Set methods for dependent properties
         %
@@ -268,6 +282,10 @@ classdef IX_sample
         function obj=set.temperature(obj,val)
             obj.temperature_=val;
         end
+
+        function obj=set.hall_symbol(obj,val)
+            obj.hall_symbol_=val;
+        end
         
         %------------------------------------------------------------------
         % Get methods for dependent properties
@@ -290,17 +308,21 @@ classdef IX_sample
         function val=get.shape(obj)
             val=obj.shape_;
         end
-        
+
         function val=get.ps(obj)
             val=obj.ps_;
         end
-        
+
         function val=get.eta(obj)
             val=obj.eta_;
         end
-        
+
         function val=get.temperature(obj)
             val=obj.temperature_;
+        end
+
+        function val=get.hall_symbol(obj)
+            val=obj.hall_symbol_;
         end
         %------------------------------------------------------------------
     end


### PR DESCRIPTION
Simple addition of the Hall Symbol to the IX_sample object. 

This makes no assertions about the structure or format of the symbol other than it is a string. 

@g5t: Additional validation could be added if it would be useful, appropriate and could be well defined. Comparing the user value against a list of "valid" values would require us to copy the some of the data included in Brille across to Herbert.

Fixes #163