### PR TITLE
Fix error in Windows Jenkins jobs run concurrently

### DIFF
--- a/_test/common_functions/MPI_Test_Common.m
+++ b/_test/common_functions/MPI_Test_Common.m
@@ -21,6 +21,7 @@ classdef MPI_Test_Common < TestCase
     properties(Access=private)
         current_config_folder;
         parallel_config_;
+        old_parallel_config_;
     end
     
     methods
@@ -32,8 +33,8 @@ classdef MPI_Test_Common < TestCase
             else
                 obj.framework_name = 'parpool';
             end
-            
-            pc = parallel_config;
+
+            [pc, obj.old_parallel_config_] = set_local_parallel_config();
             if strcmpi(pc.parallel_framework,'none')
                 obj.ignore_test = true;
                 warning('MPI_Test_Common:not_available',...
@@ -89,8 +90,7 @@ classdef MPI_Test_Common < TestCase
             if obj.ignore_test
                 return;
             end
-            
-            set(parallel_config,obj.old_config);
+            set(parallel_config,obj.old_parallel_config_);
             obj.parallel_config_.saveable = true;
         end
         function delete(obj)

--- a/_test/test_mpi_wrappers/test_CPP_MPI_exchange.m
+++ b/_test/test_mpi_wrappers/test_CPP_MPI_exchange.m
@@ -1,10 +1,9 @@
-classdef test_CPP_MPI_exchange < TestCase
+classdef test_CPP_MPI_exchange < MPI_Test_Common
     %
     % $Revision:: 833 ($Date:: 2019-10-24 20:46:09 +0100 (Thu, 24 Oct 2019) $)
     %
 
     properties
-        original_parallel_config;
     end
     methods
         %
@@ -12,13 +11,7 @@ classdef test_CPP_MPI_exchange < TestCase
             if ~exist('name', 'var')
                 name = 'test_CPP_MPI_exchange';
             end
-            obj = obj@TestCase(name);
-
-            [~, obj.original_parallel_config] = set_local_parallel_config();
-        end
-        %
-        function tearDown(obj)
-            set(parallel_config, obj.original_parallel_config);
+            obj = obj@MPI_Test_Common(name);
         end
         %
         function test_JobExecutor(obj)

--- a/_test/test_mpi_wrappers/test_FileBaseMPI_Framework.m
+++ b/_test/test_mpi_wrappers/test_FileBaseMPI_Framework.m
@@ -1,14 +1,9 @@
-classdef test_FileBaseMPI_Framework < TestCase
+classdef test_FileBaseMPI_Framework < MPI_Test_Common
     %
     % $Revision:: 833 ($Date:: 2019-10-24 20:46:09 +0100 (Thu, 24 Oct 2019) $)
     %
 
     properties
-        working_dir
-        old_config
-        % if default current framework is not a Herbert framework,
-        % one need to change the setup
-        change_setup = false;
     end
     methods
         %
@@ -16,29 +11,7 @@ classdef test_FileBaseMPI_Framework < TestCase
             if ~exist('name', 'var')
                 name = 'test_FileBaseMPI_Framework';
             end
-            this = this@TestCase(name);
-            this.working_dir = tmp_dir;
-            pc = parallel_config;
-            if strcmpi(pc.parallel_framework, 'herbert')
-                this.change_setup = false;
-            else
-                this.old_config = pc.get_data_to_store;
-                pc.parallel_framework = 'herbert';
-                this.change_setup = true;
-            end
-        end
-        %
-        function setUp(obj)
-            [pc, ~] = set_local_parallel_config();
-            if obj.change_setup
-                pc.parallel_framework = 'herbert';
-            end
-        end
-        %
-        function tearDown(obj)
-            if obj.change_setup
-                set(parallel_config, obj.old_config);
-            end
+            this = this@MPI_Test_Common(name, 'herbert');
         end
         %
         function test_finalize_all(this)


### PR DESCRIPTION
This PR makes `MPI_Tests_Common` (which most MPI tests inherit from) call `set_local_parallel_config()` on construction. It will restore the previous config on `tearDown`. 

`set_local_parallel_config` moves the config directory to `tempdir()/config`, CMake sets the environment variable `TMP` to point to within the build directory, so each Jenkins job should now have a unique place it stores its config. We do a similar thing for the message exchange folders. This should prevent the two jobs reading/writing files in the same location.

Fixes: #113
Fixes: https://github.com/pace-neutrons/Horace/issues/168