### PR TITLE
Add support for arrays of `IX_inst`

### DIFF
--- a/_test/test_instrument_classes/test_IX_inst.m
+++ b/_test/test_instrument_classes/test_IX_inst.m
@@ -109,5 +109,12 @@ classdef test_IX_inst < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
+        function test_array_of_heterogeneous_instruments_is_valid (self)
+            inst_disk = IX_inst_DGdisk(self.mod_DGdisk, self.shape_DGdisk, ...
+                self.mono_DGdisk, self.hdiv_DGdisk, self.vdiv_DGdisk);
+            inst_fermi = IX_inst_DGfermi();
+
+            assertTrue(isa([inst_disk, inst_fermi], 'IX_inst'));
+        end
     end
 end

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
@@ -1,4 +1,4 @@
-classdef IX_inst
+classdef IX_inst < matlab.mixin.Heterogeneous
     % Defines the base instrument class. This superclass must be
     % inherited by all instrumnet classes to unsure that they are
     % discoverable as instruments using isa(my_obj,'IX_inst')


### PR DESCRIPTION
Add Heterogeneous mixin to IX_inst base class. This allows the creation of arrays of `IX_inst` subclass containing a mix of child classes (e.g. `IX_inst_DGdisk` and `IX_inst_DGfermi`

Part of https://github.com/pace-neutrons/Horace/issues/136