### PR TITLE
Add seed_rng to _test/common_functions

### DIFF
--- a/_test/common_functions/seed_rng.m
+++ b/_test/common_functions/seed_rng.m
@@ -1,0 +1,11 @@
+function [state, old_state] = seed_rng(seed)
+% Seed Matlab's random number generator
+%   If no explicit seed is passed to this function, a new seed will be
+%   generated using the current time.
+
+old_state = rng();
+if nargin < 1
+    seed = mod(posixtime(datetime('now'))*1e3, 1e6);
+end
+rng(seed);
+state = rng();


### PR DESCRIPTION
This function seeds Matlab's RNG so that we can get reproducibility in tests that may require randomness.

This function currently lies in `Horace/_test/test_tobyfit` but should be made accessible elsewhere. I tried putting it in `Horace/_test/common_functions` but for some reason it was not on the path when the Horace tests were run. In any case, this is a better place for this function.