### PR TITLE
Set relative RPATH on cpp_communicator on Linux

### DIFF
--- a/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
+++ b/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries("${MEX_NAME}" "${MPI_CXX_LIBRARIES}")
 if(UNIX)
     # For MPICH on Linux we need to set relative RPATH values so dynamic libs
     # can be located by the mex library
-    file(RELATIVE_PATH _mpich_lib_file "${COPY_DESTINATION}" "${MPI_mpi_LIBRARY}")
+    file(RELATIVE_PATH _mpich_lib_file "${COPY_DESTINATION}" "${MPI_LIBRARY}")
     get_filename_component(_mpich_lib_dir "${_mpich_lib_file}" DIRECTORY)
     set_target_properties("${MEX_NAME}"
         PROPERTIES

--- a/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
+++ b/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
@@ -30,8 +30,9 @@ if(UNIX)
     set(Herbert_MPICH_LIB_RPATH "\$ORIGIN/${_mpich_lib_dir}")
     # Using the recommended BUILD_RPATH property did not work with CMake 3.7 so
     # the link flags are set explicitly.
+    get_target_property(_link_flags "${MEX_NAME}" LINK_FLAGS)
     set_target_properties("${MEX_NAME}"
         PROPERTIES
-            LINK_FLAGS "-Wl,-rpath,${Herbert_MPICH_LIB_RPATH}"
+            LINK_FLAGS "${_link_flags} -Wl,-rpath,${Herbert_MPICH_LIB_RPATH}"
     )
 endif()

--- a/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
+++ b/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
@@ -23,13 +23,15 @@ target_include_directories("${MEX_NAME}"
 target_link_libraries("${MEX_NAME}" "${MPI_CXX_LIBRARIES}")
 
 if(UNIX)
-    # For MPICH on Linux we need to set relative RPATH values so dynamic libs
-    # can be located by the mex library
+    # For MPICH on Linux it's necessary to set relative RPATH values so dynamic
+    # libraries can be located by the mex library.
     file(RELATIVE_PATH _mpich_lib_file "${COPY_DESTINATION}" "${MPI_LIBRARY}")
     get_filename_component(_mpich_lib_dir "${_mpich_lib_file}" DIRECTORY)
+    set(Herbert_MPICH_LIB_RPATH "\$ORIGIN/${_mpich_lib_dir}")
+    # Using the recommended BUILD_RPATH property did not work with CMake 3.7 so
+    # the link flags are set explicitly.
     set_target_properties("${MEX_NAME}"
         PROPERTIES
-            BUILD_RPATH "${_mpich_lib_dir}"
-            INSTALL_RPATH "${_mpich_lib_dir}"
+            LINK_FLAGS "-Wl,-rpath,${Herbert_MPICH_LIB_RPATH}"
     )
 endif()

--- a/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
+++ b/_LowLevelCode/cpp/cpp_communicator/CMakeLists.txt
@@ -11,12 +11,25 @@ set(HDR_FILES
 )
 
 set(MEX_NAME "cpp_communicator")
+set(COPY_DESTINATION "${CMAKE_SOURCE_DIR}/herbert_core/DLL")
 pace_add_mex(
     NAME "${MEX_NAME}"
     SRC "${SRC_FILES}" "${HDR_FILES}"
-    COPY_TO "${CMAKE_SOURCE_DIR}/herbert_core/DLL"
+    COPY_TO "${COPY_DESTINATION}"
 )
 target_include_directories("${MEX_NAME}"
     PRIVATE "${CXX_SOURCE_DIR}"
     PRIVATE "${MPI_CXX_INCLUDE_PATH}")
 target_link_libraries("${MEX_NAME}" "${MPI_CXX_LIBRARIES}")
+
+if(UNIX)
+    # For MPICH on Linux we need to set relative RPATH values so dynamic libs
+    # can be located by the mex library
+    file(RELATIVE_PATH _mpich_lib_file "${COPY_DESTINATION}" "${MPI_mpi_LIBRARY}")
+    get_filename_component(_mpich_lib_dir "${_mpich_lib_file}" DIRECTORY)
+    set_target_properties("${MEX_NAME}"
+        PROPERTIES
+            BUILD_RPATH "${_mpich_lib_dir}"
+            INSTALL_RPATH "${_mpich_lib_dir}"
+    )
+endif()


### PR DESCRIPTION
The Linux version of `cpp_communicator.mex` requires dynamically linked MPICH libraries. This means we need a way to point to the required `.so` libs. I've done this by setting a relative RPATH value on the mex library. 

I toyed with using the `LD_LIBRARY_PATH` environment variable, which worked, but only if the environment variable was set before Matlab was launched. Using `setenv('LD_LIBRARY_PATH`, ...)` from within Matlab did not work. Using RPATH means users do not need to worry about setting any environment variables.

Fixes #170 
Fixes https://github.com/pace-neutrons/Horace/issues/260