### PR TITLE
bug in tmpdir on idaaas

### DIFF
--- a/herbert_core/admin/tmp_dir.m
+++ b/herbert_core/admin/tmp_dir.m
@@ -16,7 +16,7 @@ if is_idaaas()
         location = getenv('HOME');
     end
     the_dir = fullfile(location,'tmp');
-    if ~exist(the_dir,'dir') == 7
+    if ~(exist(the_dir,'dir') == 7)
         [ok,the_dir,mess] = try_to_create_folder(location,'tmp');
         if ~ok
             warning('TMP_DIR:runtime_error',...

--- a/herbert_core/admin/tmp_dir.m
+++ b/herbert_core/admin/tmp_dir.m
@@ -6,9 +6,6 @@ function the_dir= tmp_dir()
 % tmp_dir     tempdir value on any machine  and (userpath()/tmp)
 %            (usually /home/user_name/Documents/MATLAB/tmp) folder if the machine is
 %            identified as iDaaaaS machine.
-%
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
-%
 
 if is_idaaas()
     location = userpath();
@@ -16,9 +13,18 @@ if is_idaaas()
         location = fileparts(which('startup.m'));
     end
     if isempty(location)
-        location = getenv('HOME');        
+        location = getenv('HOME');
     end
     the_dir = fullfile(location,'tmp');
+    if ~exist(the_dir,'dir') == 7
+        [ok,the_dir,mess] = try_to_create_folder(location,'tmp');
+        if ~ok
+            warning('TMP_DIR:runtime_error',...
+                ' Can not create temporary folder in user directory: %s. Reason: %s Reverting to system tmp folder',...
+                location,mess);
+            the_dir = tempdir();
+        end
+    end
     % dereference simulinks and obtain real path
     [~,fatr] = fileattrib(the_dir);
     the_dir = [fatr.Name,filesep];

--- a/herbert_core/utilities/misc/make_config_folder.m
+++ b/herbert_core/utilities/misc/make_config_folder.m
@@ -33,7 +33,6 @@ function folder_path=make_config_folder(folder_name,in_folder_path)
 % usually the same for a given machine, so the path to the configurations
 % will be the same next next time the function is called.
 
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 
 if exist('in_folder_path','var')
     [success,folder_path,err_mess] = try_to_create_folder(in_folder_path,folder_name);
@@ -107,27 +106,3 @@ end
 
 
 %--------------------------------------------------------------------------------------------------
-function [success,folder_path,mess]=try_to_create_folder(location,folder_name)
-folder_path = [location,filesep,folder_name];
-
-ic = 0;
-if ~exist(folder_path,'dir')
-    [success, mess] = mkdir(folder_path);
-    while ~(exist(folder_path,'dir') || ic<3)
-        [success, mess] = mkdir(folder_path);
-        ic = ic + 1;
-        pause(0.1);
-    end
-else
-    test_path = fullfile(folder_path,['folder_twa_',char(randi(25,1,10) + 64)]);
-    %clob = onCleanup(@()rmdir(test_path));
-    [success, mess] = mkdir(test_path);
-    if success
-        [statrm,msg] = rmdir(test_path);
-        if ~statrm
-            warning('MAKE_CONFIG_FOLDER:runtime_error',...
-                ' Can not remove test folder %s; message: %s',test_path,msg);
-        end
-    end
-end
-

--- a/herbert_core/utilities/misc/try_to_create_folder.m
+++ b/herbert_core/utilities/misc/try_to_create_folder.m
@@ -1,0 +1,38 @@
+function [success,folder_path,mess]=try_to_create_folder(location,folder_name)
+% The function tries to creates folder in specified directory, checking for
+% it existence first. If folder exists, the routine checks that this folder is
+% accessible for writing. 
+% 
+% Inputs:
+% location       -- the topmost location, where the folder should be created
+% folder_name    -- the name of the folder to create
+%
+% Returns:
+% success     -- true if the folder is created and available for writing or
+%                exists and is available for writing.
+% folder_path -- the path to the created folder.
+% mess        -- empty if success or reason for the issue if it was not.
+%
+folder_path = [location,filesep,folder_name];
+
+ic = 0;
+if ~exist(folder_path,'dir')
+    [success, mess] = mkdir(folder_path);
+    while ~(exist(folder_path,'dir') || ic<3)
+        [success, mess] = mkdir(folder_path);
+        ic = ic + 1;
+        pause(0.1);
+    end
+else
+    test_path = fullfile(folder_path,['folder_twa_',char(randi(25,1,10) + 64)]);
+    %clob = onCleanup(@()rmdir(test_path));
+    [success, mess] = mkdir(test_path);
+    if success
+        [statrm,msg] = rmdir(test_path);
+        if ~statrm
+            warning('MAKE_CONFIG_FOLDER:runtime_error',...
+                ' Can not remove test folder %s; message: %s',test_path,msg);
+        end
+    end
+end
+

--- a/herbert_core/utilities/misc/try_to_create_folder.m
+++ b/herbert_core/utilities/misc/try_to_create_folder.m
@@ -25,7 +25,6 @@ if ~exist(folder_path,'dir')
     end
 else
     test_path = fullfile(folder_path,['folder_twa_',char(randi(25,1,10) + 64)]);
-    %clob = onCleanup(@()rmdir(test_path));
     [success, mess] = mkdir(test_path);
     if success
         [statrm,msg] = rmdir(test_path);


### PR DESCRIPTION
The issue user experienced was that if tmp folder on idaaas does not exist, Horace initialization was failing. I think, the solution is straightforward -- create such folder. 