### PR TITLE
Add help to build scripts

### DIFF
--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -25,19 +25,19 @@
   https://github.com/pace-neutrons/Herbert
 #>
 param (
-  # Run the Herbert build commands
+  # Run the Herbert build commands.
   [switch][Alias("b")]$build,
-  # Run all Herbert tests
+  # Run all Herbert tests.
   [switch][Alias("t")]$test,
-  # Pacakge Herbert into a .zip file
+  # Pacakge Herbert into a .zip file.
   [switch][Alias("p")]$package,
-  # Print the versions of libraries being used e.g. Matlab
+  # Print the versions of libraries being used e.g. Matlab.
   [switch][Alias("v")]$print_versions,
-  # Call Get-Help on this script and exit
+  # Call Get-Help on this script and exit.
   [switch][Alias("h")]$help,
 
-  # The version of Visual Studio to build with (one of 2015, 2017, 2019).
-  # Other Windows compilers are not supported by this script. {2015, 2017, 2019}
+  # The version of Visual Studio to build with. Other Windows compilers are
+  # not supported by this script. {2015, 2017, 2019}
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 2017,

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -37,24 +37,24 @@ param (
   [switch][Alias("h")]$help,
 
   # The version of Visual Studio to build with. Other Windows compilers are
-  # not supported by this script. {2015, 2017, 2019}
+  # not supported by this script. {2015, 2017, 2019} [default: 2017]
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 2017,
 
   # Whether to build the Herbert C++ tests and enable testing via CTest.
-  # This must be "ON" in order to run tests with this script. {"ON", "OFF"}
+  # This must be "ON" in order to run tests with this script. {ON, OFF} [default: ON]
   [string][ValidateSet("ON", "OFF")]
   [Alias("X")]
   $build_tests = "ON",
 
-  # The configuration to build with. {Release, Debug}
+  # The configuration to build with. {Release, Debug} [default: Release]
   [string][ValidateSet("Release", "Debug")]
   [Alias("C")]
   $build_config = 'Release',
 
   # The directory to write build files into. If the directory does not exist it
-  # will be created.
+  # will be created. [default: build]
   [string]
   [Alias("O")]
   $build_dir = "",

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -3,8 +3,8 @@
   This script is used to build, test and package Herbert on Windows.
 
 .DESCRIPTION
-  This script requires Matlab, Visual Studio, CMake and CTest be installed on
-  your system and be available on the path.
+  This script requires Matlab, Visual Studio, CMake>=3.7 and CTest be installed
+  on your system and available on the path.
 
   Use "Get-Help ./build.ps1 -Detailed" for parameter descriptions.
 
@@ -78,7 +78,7 @@ if ($args) {
   throw "$error_msg"
 }
 
-if ($help) {
+if ($help -or $PSBoundParameters.Values.Count -eq 0) {
   Get-Help "$PSCommandPath"
   exit 0
 }

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -18,7 +18,7 @@
   ./build.ps1 -package
   # Packages Herbert
 .EXAMPLE
-  ./build.ps1 -build -package -vs_version 2017 -matlab_release "R2019a"
+  ./build.ps1 -build -package -vs_version 2017 -matlab_release R2019a
   # Builds and packages Herbert using Visual Studio 2017 and Matlab R2019a
 
 .LINK

--- a/tools/build_config/build.ps1
+++ b/tools/build_config/build.ps1
@@ -1,29 +1,70 @@
-param (
-  [switch][Alias("b")]$build,
-  [switch][Alias("t")]$test,
-  [switch][Alias("p")]$package,
-  [switch][Alias("v")]$print_versions,
+<#
+.SYNOPSIS
+  This script is used to build, test and package Herbert on Windows.
 
+.DESCRIPTION
+  This script requires Matlab, Visual Studio, CMake and CTest be installed on
+  your system and be available on the path.
+
+  Use "Get-Help ./build.ps1 -Detailed" for parameter descriptions.
+
+.EXAMPLE
+  ./build.ps1 -build
+  # Builds Herbert
+.EXAMPLE
+  ./build.ps1 -test
+  # Runs all Herbert tests
+.EXAMPLE
+  ./build.ps1 -package
+  # Packages Herbert
+.EXAMPLE
+  ./build.ps1 -build -package -vs_version 2017 -matlab_release "R2019a"
+  # Builds and packages Herbert using Visual Studio 2017 and Matlab R2019a
+
+.LINK
+  https://github.com/pace-neutrons/Herbert
+#>
+param (
+  # Run the Herbert build commands
+  [switch][Alias("b")]$build,
+  # Run all Herbert tests
+  [switch][Alias("t")]$test,
+  # Pacakge Herbert into a .zip file
+  [switch][Alias("p")]$package,
+  # Print the versions of libraries being used e.g. Matlab
+  [switch][Alias("v")]$print_versions,
+  # Call Get-Help on this script and exit
+  [switch][Alias("h")]$help,
+
+  # The version of Visual Studio to build with (one of 2015, 2017, 2019).
+  # Other Windows compilers are not supported by this script. {2015, 2017, 2019}
   [int][ValidateSet(2015, 2017, 2019)]
   [Alias("VS")]
   $vs_version = 2017,
 
+  # Whether to build the Herbert C++ tests and enable testing via CTest.
+  # This must be "ON" in order to run tests with this script. {"ON", "OFF"}
   [string][ValidateSet("ON", "OFF")]
   [Alias("X")]
   $build_tests = "ON",
 
+  # The configuration to build with. {Release, Debug}
   [string][ValidateSet("Release", "Debug")]
   [Alias("C")]
   $build_config = 'Release',
 
+  # The directory to write build files into. If the directory does not exist it
+  # will be created.
   [string]
   [Alias("O")]
   $build_dir = "",
 
+  # Flags to pass to the CMake configure step.
   [string]
   [Alias("F")]
   $cmake_flags = "",
 
+  # The release of Matlab to build and run tests against e.g. R2018b.
   [string][ValidatePattern("R[0-9]{4}[ab]")]
   [Alias("M")]
   $matlab_release = ""
@@ -35,6 +76,11 @@ if ($args) {
     $error_msg += "`n    $arg"
   }
   throw "$error_msg"
+}
+
+if ($help) {
+  Get-Help "$PSCommandPath"
+  exit 0
 }
 
 # Mapping from year to Visual Studio version

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -106,7 +106,7 @@ flags:
   -a, --analyze
       Run static analysis on Herbert C++ code.
   -p, --package
-      Pacakge Herbert into a .zip file.
+      Pacakge Herbert into a .tar.gz file.
   -v, --print_versions
       Print the versions of libraries being used e.g. Matlab.
   -h, --help

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -91,6 +91,46 @@ function run_package() {
   echo_and_run "cpack -G TGZ"
 }
 
+function print_help() {
+  help_msg="Script to build, run static analysis, test and package Herbert.
+
+https://github.com/pace-neutrons/Herbert
+
+usage:
+  ./build.sh flag1 [flag2 [flag3]...] [option1 argument1 [option2 argument2]...]
+flags:
+  -b, --build
+      Run the Herbert build commands.
+  -t, --test
+      Run all Herbert tests.
+  -a, --analyze
+      Run static analysis on Herbert C++ code.
+  -p, --package
+      Pacakge Herbert into a .zip file.
+  -v, --print_versions
+      Print the versions of libraries being used e.g. Matlab.
+  -h, --help
+      Print help message and exit
+options:
+  -X, --build_tests {\"ON\", \"OFF\"}
+      Whether to build the Herbert C++ tests and enable testing via CTest.
+      This must be \"ON\" in order to run tests with this script. [default: ON]
+  -C, --build_config {\"Release\", \"Debug\"}
+      The build configuration passed to CMake [default: Release]
+  -O, --build_dir
+      The directory to write build files into. If the directory does not exist
+      it will be created. [default: build]
+  -F, --cmake_flags
+      Flags to pass to the CMake configure step.
+  -M, --matlab_release
+      The release of Matlab to build and run tests against e.g. R2018b. This
+      Matlab release should also be on your path.
+example:
+  ./build.sh --build --test --build_config Debug
+"
+  echo -e "${help_msg}"
+}
+
 function main() {
   # set default parameter values
   local build=$FALSE
@@ -104,6 +144,12 @@ function main() {
   local cmake_flags=""
   local matlab_release=""
 
+  # If no input arguments, print the help and exit with error code
+  if [ $# -eq 0 ]; then
+    print_help
+    exit 1
+  fi
+
   # parse command line args
   while [[ $# -gt 0 ]]; do
     key="$1"
@@ -114,13 +160,14 @@ function main() {
         -a|--analyze) analyze=$TRUE; shift ;;
         -p|--package) package=$TRUE; shift ;;
         -v|--print_versions) print_versions=$TRUE; shift ;;
+        -h|--help) print_help; exit 0 ;;
         # options
         -X|--build_tests) build_tests="$2"; shift; shift ;;
         -C|--build_config) build_config="$2"; shift; shift ;;
         -O|--build_dir) build_dir="$(realpath "$2")"; shift; shift ;;
         -F|--cmake_flags) cmake_flags="$2"; shift; shift ;;
         -M|--matlab_release) matlab_release="$2"; shift; shift ;;
-        *) echo "Unrecognised argument '$key'"; exit 1 ;;
+        *) echo "Unrecognised argument '$key'. Use -h for usage."; exit 1 ;;
     esac
   done
 

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -94,6 +94,9 @@ function run_package() {
 function print_help() {
   readonly local help_msg="Script to build, run static analysis, test and package Herbert.
 
+This script requires Matlab, GCC, CMake>=3.7 and CTest be installed on your
+system and available on the path.
+
 https://github.com/pace-neutrons/Herbert
 
 usage:

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -92,7 +92,7 @@ function run_package() {
 }
 
 function print_help() {
-  help_msg="Script to build, run static analysis, test and package Herbert.
+  readonly local help_msg="Script to build, run static analysis, test and package Herbert.
 
 https://github.com/pace-neutrons/Herbert
 

--- a/tools/build_config/build.sh
+++ b/tools/build_config/build.sh
@@ -144,10 +144,10 @@ function main() {
   local cmake_flags=""
   local matlab_release=""
 
-  # If no input arguments, print the help and exit with error code
+  # If no input arguments, print the help and exit
   if [ $# -eq 0 ]; then
     print_help
-    exit 1
+    exit 0
   fi
 
   # parse command line args


### PR DESCRIPTION
This PR adds help to Herbert's `build.ps1` and `build.sh` build scripts. The help messages should be printed given the `-h` or `-help` flags in PowerShell and  the -h` or `--help` flags in bash. Help should also be printed if no arguments are passed to the help scripts.

Refs: https://github.com/pace-neutrons/Horace/issues/257

Fixes #179 