### PR TITLE
bug in optimal configuration

### DIFF
--- a/herbert_core/admin/@opt_config_manager/OptimalConfigInfo.xml
+++ b/herbert_core/admin/@opt_config_manager/OptimalConfigInfo.xml
@@ -121,7 +121,7 @@
       </hpc_config>
       <parallel_config>
          <worker>worker_v2</worker>
-         <parallel_framework>herbert</parallel_framework>
+         <parallel_framework>parpool</parallel_framework>
          <cluster_config>local</cluster_config>
          <shared_folder_on_local/>
          <shared_folder_on_remote/>

--- a/herbert_core/admin/@opt_config_manager/private/find_comp_type_.m
+++ b/herbert_core/admin/@opt_config_manager/private/find_comp_type_.m
@@ -34,8 +34,8 @@ if ispc
     end
 elseif isunix
     
-    [ok,mem_string] = system('free | grep Mem');
-    if ~ok
+    [stat,mem_string] = system('free | grep Mem');
+    if stat ~=0
         mem_size = 16*Gb;
     else
         mem_size = parse_mem_string(mem_string);


### PR DESCRIPTION
It was not identifying iDaaaS machines correctly. Should be fixed now. 