### PR TITLE
Move Jenkins pipeline param declaration into Jenkinsfile

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -1,13 +1,113 @@
 #!groovy
-/**
- * The following parameters must be provided by the Jenkins build job and must match available application
- * on the build target machine
- *
- *  - CMAKE_VERSION: The version of CMake to run the build with
- *  - GCC_VERSION: The version of GCC to build with
- *  - MATLAB_VERSION: The release number of the Matlab to load
- *  - CPPCHECK_VERSION: The version of CppCheck tooling to load to provide the code-style checks
- */
+
+def get_matlab_release(String job_name) {
+  return job_name[-5..-1]
+}
+
+def get_build_type(String job_name) {
+  if (env.JOB_BASE_NAME.startswith('Release-')) {
+    return 'Release'
+  } else if (env.JOB_BASE_NAME.startswith('Branch-')) {
+    return 'Branch'
+  } else if(env.JOB_BASE_NAME.startswith('PR-')) {
+    return 'Pull-request'
+  } else {
+    return 'Nightly'
+  }
+}
+
+def get_agent(String job_name) {
+  def agent = ''
+  if (env.JOB_BASE_NAME.contains('Scientific-Linux-7')) {
+    return 'sl7'
+  } else if (env.JOB_BASE_NAME.contains('Windows-10')) {
+    return 'PACE Windows (Private)'
+  }
+  return '';
+}
+
+def get_release_type(String job_name) {
+  String build_type = get_build_type(job_name);
+
+  switch(build_type) {
+    case 'Release':
+      return 'release'
+
+    case 'Pull-request':
+      return 'pull_request'
+
+    case 'Nightly':
+      return 'nightly'
+
+    default:
+      return ''
+  }
+}
+
+def get_branch_name(String job_name) {
+  String build_type = get_build_type(job_name);
+
+  switch(build_type) {
+    case 'Nightly':
+      return 'master'
+
+    default:
+      return ''
+  }
+}
+
+properties([
+  parameters([
+    string(
+      defaultValue: get_agent(env.JOB_BASE_NAME),
+      description: 'The agent to execute the pipeline on.',
+      name: 'AGENT',
+      trim: true
+    ),
+    string(
+      defaultValue: get_branch_name(env.JOB_BASE_NAME),
+      description: 'The name of the branch to build.',
+      name: 'BRANCH_NAME',
+      trim: true
+    ),
+    string(
+      defaultValue: get_matlab_release(env.JOB_BASE_NAME),
+      description: 'The release number of the Matlab to load.',
+      name: 'MATLAB_VERSION', trim: true
+    ),
+    string(
+      defaultValue: get_release_type(env.JOB_BASE_NAME),
+      description: 'The type of the build e.g. "nightly", "release", "pull_request".',
+      name: 'RELEASE_TYPE',
+      trim: true
+    ),
+    string(
+      defaultValue: '3.7.2',
+      description: 'The version of CMake to run the build with.',
+      name: 'CMAKE_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '6.3.0',
+      description: 'The version of GCC to build with.',
+      name: 'GCC_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '2017',
+      description: 'The year of the version of Visual Studio to build with.',
+      name: 'VS_VERSION',
+      trim: true
+    ),
+    string(
+      defaultValue: '1.77',
+      description: 'The version of CppCheck tooling to load to provide the code-style checks.',
+      name: 'CPPCHECK_VERSION',
+      trim: true
+    )
+  ])
+])
+
 
 def post_github_status(String state, String message) {
   // Non-PR builds will not set PR_STATUSES_URL - in which case we do not
@@ -48,16 +148,6 @@ def post_github_status(String state, String message) {
   }
 }
 
-/* Required pipeline parameters:
- *   All platforms:
- *     AGENT (e.g. 'sl7', 'PACE Windows (Private)', 'osx')
- *     MATLAB_VERSION (e.g R2018b)
- *     RELEASE_TYPE ('nightly', 'release' - optional)
- *   Unix only:
- *     CMAKE_VERSION  (e.g. 3.7.2)
- *     GCC_VERSION (e.g. 6.3.0)
- *     CPPCHECK_VERSION (e.g. 1.77)
-*/
 pipeline {
   agent {
     label env.AGENT

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -25,8 +25,10 @@ def get_agent(String job_name) {
     withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
       return "${agent}"
     }
+  } else {
+    // This else block is required or the below statement will always execute
+    return '';
   }
-  return '';
 }
 
 def get_release_type(String job_name) {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -18,9 +18,13 @@ def get_build_type(String job_name) {
 
 def get_agent(String job_name) {
   if (job_name.contains('Scientific-Linux-7')) {
-    return 'sl7'
+    withCredentials([string(credentialsId: 'sl7_agent', variable: 'agent')]) {
+      return "${agent}"
+    }
   } else if (job_name.contains('Windows-10')) {
-    return 'PACE Windows (Private)'
+    withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
+      return "${agent}"
+    }
   }
   return '';
 }

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -17,7 +17,6 @@ def get_build_type(String job_name) {
 }
 
 def get_agent(String job_name) {
-  def agent = ''
   if (job_name.contains('Scientific-Linux-7')) {
     return 'sl7'
   } else if (job_name.contains('Windows-10')) {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -58,27 +58,27 @@ def get_branch_name(String job_name) {
 properties([
   parameters([
     string(
-      defaultValue: get_agent(env.JOB_BASE_NAME),
-      description: 'The agent to execute the pipeline on.',
-      name: 'AGENT',
-      trim: true
-    ),
-    string(
       defaultValue: get_branch_name(env.JOB_BASE_NAME),
       description: 'The name of the branch to build.',
       name: 'BRANCH_NAME',
       trim: true
     ),
     string(
-      defaultValue: get_matlab_release(env.JOB_BASE_NAME),
-      description: 'The release number of the Matlab to load e.g. R2019b.',
-      name: 'MATLAB_VERSION', trim: true
-    ),
-    string(
       defaultValue: get_release_type(env.JOB_BASE_NAME),
       description: 'The type of the build e.g. "nightly", "release", "pull_request".',
       name: 'RELEASE_TYPE',
       trim: true
+    ),
+    string(
+      defaultValue: get_agent(env.JOB_BASE_NAME),
+      description: 'The agent to execute the pipeline on.',
+      name: 'AGENT',
+      trim: true
+    ),
+    string(
+      defaultValue: get_matlab_release(env.JOB_BASE_NAME),
+      description: 'The release number of the Matlab to load e.g. R2019b.',
+      name: 'MATLAB_VERSION', trim: true
     ),
     string(
       defaultValue: '3.7.2',

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -5,11 +5,11 @@ def get_matlab_release(String job_name) {
 }
 
 def get_build_type(String job_name) {
-  if (env.JOB_BASE_NAME.startsWith('Release-')) {
+  if (job_name.startsWith('Release-')) {
     return 'Release'
-  } else if (env.JOB_BASE_NAME.startsWith('Branch-')) {
+  } else if (job_name.startsWith('Branch-')) {
     return 'Branch'
-  } else if(env.JOB_BASE_NAME.startsWith('PR-')) {
+  } else if(job_name.startsWith('PR-')) {
     return 'Pull-request'
   } else {
     return 'Nightly'
@@ -18,9 +18,9 @@ def get_build_type(String job_name) {
 
 def get_agent(String job_name) {
   def agent = ''
-  if (env.JOB_BASE_NAME.contains('Scientific-Linux-7')) {
+  if (job_name.contains('Scientific-Linux-7')) {
     return 'sl7'
-  } else if (env.JOB_BASE_NAME.contains('Windows-10')) {
+  } else if (job_name.contains('Windows-10')) {
     return 'PACE Windows (Private)'
   }
   return '';

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 def get_matlab_release(String job_name) {
-  return job_name[-5..-1]
+  return 'R' + job_name[-5..-1]
 }
 
 def get_build_type(String job_name) {
@@ -72,7 +72,7 @@ properties([
     ),
     string(
       defaultValue: get_matlab_release(env.JOB_BASE_NAME),
-      description: 'The release number of the Matlab to load.',
+      description: 'The release number of the Matlab to load e.g. R2019b.',
       name: 'MATLAB_VERSION', trim: true
     ),
     string(

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -17,18 +17,17 @@ def get_build_type(String job_name) {
 }
 
 def get_agent(String job_name) {
+  def agent = ''
   if (job_name.contains('Scientific-Linux-7')) {
     withCredentials([string(credentialsId: 'sl7_agent', variable: 'agent')]) {
-      return "${agent}"
+      agent = "${agent}"
     }
   } else if (job_name.contains('Windows-10')) {
     withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
-      return "${agent}"
+      agent = "${agent}"
     }
-  } else {
-    // This else block is required or the below statement will always execute
-    return '';
   }
+  return agent
 }
 
 def get_release_type(String job_name) {

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -5,11 +5,11 @@ def get_matlab_release(String job_name) {
 }
 
 def get_build_type(String job_name) {
-  if (env.JOB_BASE_NAME.startswith('Release-')) {
+  if (env.JOB_BASE_NAME.startsWith('Release-')) {
     return 'Release'
-  } else if (env.JOB_BASE_NAME.startswith('Branch-')) {
+  } else if (env.JOB_BASE_NAME.startsWith('Branch-')) {
     return 'Branch'
-  } else if(env.JOB_BASE_NAME.startswith('PR-')) {
+  } else if(env.JOB_BASE_NAME.startsWith('PR-')) {
     return 'Pull-request'
   } else {
     return 'Nightly'


### PR DESCRIPTION
This PR moves the declaration of pipeline parameters into the Jenkinsfile. This means we shouldn't need to do as much configuration within the Jenkins GUI.

When parameters are set in the Jenkinsfile, the pipeline's configuration will update according to the parameters specified. If running from a clean pipeline (with no configuration set in the GUI) the first build will most likely fail because the parameters were not previously set. This should not be a problem for us since the parameters I've added in the Jenkinsfile are already set in the GUI, therefore builds should be unaffected.

The new Jenkinsfile deduces what the default parameter values should be using the pipeline's name. If the pipeline's name starts with `PR-` then the Jenkinsfile will set the parameter defaults that are required by the pull request pipelines. This equally applies to the Matlab version and OS.

The Jenkins SMG will need updating when the Horace equivalent of this PR is opened.

These changes and the creation of the `Release-*` pipelines in the Jenkins GUI fixes #219 

Fixes https://github.com/pace-neutrons/Horace/issues/346