### PR TITLE
Fix get_agent function in Jenkinsfile

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -17,17 +17,18 @@ def get_build_type(String job_name) {
 }
 
 def get_agent(String job_name) {
-  def agent = ''
   if (job_name.contains('Scientific-Linux-7')) {
     withCredentials([string(credentialsId: 'sl7_agent', variable: 'agent')]) {
-      agent = "${agent}"
+      return "${agent}"
     }
   } else if (job_name.contains('Windows-10')) {
     withCredentials([string(credentialsId: 'win10_agent', variable: 'agent')]) {
-      agent = "${agent}"
+      return "${agent}"
     }
+  } else {
+    return ''
   }
-  return agent
+
 }
 
 def get_release_type(String job_name) {


### PR DESCRIPTION
The function was previously only ever returning an empty string. There's
some weirdness when setting/returning variables from within a
withCredentials block.

This fix should get the pipelines back up and running properly