### PR TITLE
Jenkins release pipelines to archive text file with Git revision SHA

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -153,6 +153,22 @@ def post_github_status(String state, String message) {
   }
 }
 
+def write_git_revision_to_file(String file_name) {
+  script {
+    def git_rev_cmd = "git rev-parse HEAD"
+    if (isUnix()) {
+      sh """
+        echo "\$(${git_rev_cmd})" > ${file_name}
+      """
+    } else {
+      powershell """
+        Write-Output "\$(${git_rev_cmd})" > ${file_name}
+      """
+    }
+  }
+}
+
+
 pipeline {
   agent {
     label env.AGENT
@@ -168,6 +184,11 @@ pipeline {
           } else if (env.PR_NUMBER) {
             currentBuild.displayName = "#${env.BUILD_NUMBER} PR-${env.PR_NUMBER}"
             currentBuild.description = "Git-SHA: ${env.PR_COMMIT_SHA.take(7)}"
+          }
+
+          if (get_build_type(env.JOB_BASE_NAME) == "Release") {
+            def git_rev_file_name = "${env.BASE_JOB_NAME}-git-revision.txt"
+            write_git_revision_to_file(git_rev_file_name)
           }
         }
         post_github_status("pending", "The build is running")

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -271,18 +271,19 @@ pipeline {
               ./tools/build_config/build.ps1 -package
             '''
           }
-          // Create a file containing the git revision being built. This
+          // Archive a file containing the git revision being built. This
           // enables the Deploy pipelines to validate against this SHA, and
           // ensure the correct revision is tagged in Git.
-          if (get_build_type(env.JOB_BASE_NAME) == "Release") {
+          if (get_build_type(env.JOB_BASE_NAME) == 'Release') {
             def git_rev_file_name = "${env.JOB_BASE_NAME}-git-revision.sha"
             write_git_revision_to_file(git_rev_file_name)
+            archiveArtifacts(artifacts: git_rev_file_name, fingerprint: true)
           }
         }
 
-        // Archive the release package and Git SHA file (if it exists)
+        // Archive the release package
         archiveArtifacts(
-          artifacts: "build/Herbert-*,${git_rev_file_name}",
+          artifacts: 'build/Herbert-*',
           fingerprint: true
         )
       }

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -168,6 +168,13 @@ def write_git_revision_to_file(String file_name) {
   }
 }
 
+if (env.BRANCH_NAME) {
+  currentBuild.description = "Branch: ${env.BRANCH_NAME}"
+} else if (env.PR_NUMBER) {
+  currentBuild.displayName = "#${env.BUILD_NUMBER} PR-${env.PR_NUMBER}"
+  currentBuild.description = "Git-SHA: ${env.PR_COMMIT_SHA.take(7)}"
+}
+
 
 pipeline {
   agent {
@@ -179,13 +186,6 @@ pipeline {
     stage('Notify') {
       steps {
         script {
-          if (env.BRANCH_NAME) {
-            currentBuild.description = "Branch: ${env.BRANCH_NAME}"
-          } else if (env.PR_NUMBER) {
-            currentBuild.displayName = "#${env.BUILD_NUMBER} PR-${env.PR_NUMBER}"
-            currentBuild.description = "Git-SHA: ${env.PR_COMMIT_SHA.take(7)}"
-          }
-
           // Archive a file containing the git revision being built. This
           // enables the Deploy pipelines to validate against this SHA, and
           // ensure the correct revision is tagged in Git.

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -186,19 +186,6 @@ pipeline {
 
     stage('Notify') {
       steps {
-        script {
-          // Archive a file containing the git revision being built. This
-          // enables the Deploy pipelines to validate against this SHA, and
-          // ensure the correct revision is tagged in Git.
-          if (get_build_type(env.JOB_BASE_NAME) == "Release") {
-            def git_rev_file_name = "${env.JOB_BASE_NAME}-git-revision.txt"
-            write_git_revision_to_file(git_rev_file_name)
-            archiveArtifacts(
-              artifacts: git_rev_file_name,
-              followSymlinks: false
-            )
-          }
-        }
         post_github_status("pending", "The build is running")
       }
     }
@@ -284,11 +271,18 @@ pipeline {
               ./tools/build_config/build.ps1 -package
             '''
           }
+          // Create a file containing the git revision being built. This
+          // enables the Deploy pipelines to validate against this SHA, and
+          // ensure the correct revision is tagged in Git.
+          if (get_build_type(env.JOB_BASE_NAME) == "Release") {
+            def git_rev_file_name = "${env.JOB_BASE_NAME}-git-revision.sha"
+            write_git_revision_to_file(git_rev_file_name)
+          }
         }
 
-        // Archive the release package
+        // Archive the release package and Git SHA file (if it exists)
         archiveArtifacts(
-          artifacts: 'build/Herbert-*',
+          artifacts: "build/Herbert-*,${git_rev_file_name}",
           fingerprint: true
         )
       }

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -186,9 +186,16 @@ pipeline {
             currentBuild.description = "Git-SHA: ${env.PR_COMMIT_SHA.take(7)}"
           }
 
+          // Archive a file containing the git revision being built. This
+          // enables the Deploy pipelines to validate against this SHA, and
+          // ensure the correct revision is tagged in Git.
           if (get_build_type(env.JOB_BASE_NAME) == "Release") {
-            def git_rev_file_name = "${env.BASE_JOB_NAME}-git-revision.txt"
+            def git_rev_file_name = "${env.JOB_BASE_NAME}-git-revision.txt"
             write_git_revision_to_file(git_rev_file_name)
+            archiveArtifacts(
+              artifacts: git_rev_file_name,
+              followSymlinks: false
+            )
           }
         }
         post_github_status("pending", "The build is running")

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -156,6 +156,7 @@ def post_github_status(String state, String message) {
 def write_git_revision_to_file(String file_name) {
   script {
     def git_rev_cmd = "git rev-parse HEAD"
+    echo "Writing Git revision to ${file_name}..."
     if (isUnix()) {
       sh """
         echo "\$(${git_rev_cmd})" > ${file_name}


### PR DESCRIPTION
This PR makes additions to the Jenkinsfile such that the Git revision being built and tested is written to a file. The file is then archived to make it accessible by other pipelines.

Fixes #231 