### PR TITLE
fix noisify bugs #234, extend interface for paging

### DIFF
--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -18,13 +18,14 @@ function [yout,eout] = noisify (y,e,varargin)
 %           Add noise with Poisson distribution, where the mean value at
 %           a point is the value y.
 %
-%   >> [yout, eout] = noisify(y,e,factor,maxval)
+%   >> [yout, eout] = noisify(y,e,[factor,]'maxval',maxval)
 %           Add noise with Gaussian distribution, calculating the standard
 %           deviation by an externally provided maximum y value.
-%           Typically this will be the overall maximum value if the
+%           The max value is preceded by a keyword string 'maxval'.
+%           Typically this value will be the overall maximum value if the
 %           data is processed page by page and the maximum must be
 %           extracted before this processing.
-%           Setting factor<0.0 will use the default value 0.1.
+%           Omitting factor will use the default value 0.1.
 %
 %   If no input errors, e, just set e=[]
 

--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -37,7 +37,7 @@ if nargin>=2
     p = inputParser;
     addRequired(p,'y');   % y compulsory
     addRequired(p,'e');   % e compulsory if any of remaining optional/parameter arguments present
-    numeric_or_string = @(x) isnumeric(x) || ischar(x)
+    numeric_or_string = @(x) isnumeric(x) || ischar(x);
     addOptional(p,'dist_or_factor',fac, numeric_or_string);  % fac (numeric) or distribution ('poisson') optional, default to fac=0.1
     addParameter(p,'maximum_value',-999,@isnumeric);  % ymax, as parameter 'maximum_value'. Default to highly visible negative value.
     parse(p,y,e,varargin{:});

--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -1,6 +1,7 @@
 function [yout,eout] = noisify (y,e,varargin)
 % Adds noise to y values and associated error bars. The arrays y, e must
-% have same size.
+% have same size. y is the signal and e is its variance (not standard
+% deviation)
 %
 % Syntax:
 %   >> yout = noisify (y)
@@ -17,6 +18,14 @@ function [yout,eout] = noisify (y,e,varargin)
 %           Add noise with Poisson distribution, where the mean value at
 %           a point is the value y.
 %
+%   >> [yout, eout] = noisify(y,e,factor,maxval)
+%           Add noise with Gaussian distribution, calculating the standard
+%           deviation by an externally provided maximum y value.
+%           Typically this will be the overall maximum value if the
+%           data is processed page by page and the maximum must be
+%           extracted before this processing.
+%           Setting factor<0.0 will use the default value 0.1.
+%
 %   If no input errors, e, just set e=[]
 
 if nargin==3 && ischar(varargin{1})
@@ -25,32 +34,44 @@ if nargin==3 && ischar(varargin{1})
         for i=1:numel(y)
             yout(i)=randpoisson(abs(y(i)));
         end
-        eout=abs(y);  % the inpuy y is the mean and variance of the Poisson distribution
+        eout=abs(y);  % the input y is the mean and variance of the Poisson distribution
     else
         error('Unrecognised random sampling distribution')
     end
-else
-    if nargin==3
+else % 3rd arg did not exist or was not a distribution name
+    default_fac = 0.1;
+    if nargin>=3 % 3 args for fac or 4 args for fac and maxval
         if isnumeric(varargin{1}) && isscalar(varargin{1})
             fac = varargin{1};
+            if fac < 0.0 % default option if 4th arg is needed
+                fac = default_fac;
+            end
         else
             error('Noise as fraction of peak signal must be real scalar')
         end
     else
-        fac = 0.1;
+        fac = default_fac;
     end
-    ymax = max(abs(y(:)));          % find maximum magnitude of y for arbitrary dimensions
+    if nargin==4 % means the maxval arg has been used
+        ymax = varargin{2};             % use max value previously extracted
+    else
+        ymax = max(abs(y(:)));          % find maximum magnitude of y for arbitrary dimensions
+    end
     dy=(fac*ymax)*randn(size(y));   % st. dev. of randn is sigma=1
     yout=y+dy;
     eout=ones(size(y))*(fac*ymax)^2;
 end
 
-if exist('e','var') && isempty(e)
+% this code now outputs a variance to be consistent between the use of eout
+% in the Poisson distribution section, the input definition for e and this
+% output.
+%
+% this code now adds e (an input *variance* rather than std deviation) to
+% eout if it exists rather than if it does not.
+if exist('e','var') && ~isempty(e)
     if isequal(size(e),size(eout))
-        eout=sqrt(eout+e.^2);
+        eout=eout+e;
     else
         error('Input array of error bars must have same size as input y array')
     end
-else
-    eout=sqrt(eout);
 end

--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -1,7 +1,6 @@
 function [yout,eout] = noisify (y,e,varargin)
 % Adds noise to y values and associated error bars. The arrays y, e must
-% have same size. y is the signal and e is its variance (not standard
-% deviation)
+% have same size. y is the signal and e is its variance.
 %
 % Syntax:
 %   >> yout = noisify (y)
@@ -82,8 +81,8 @@ eout=ones(size(y))*(fac*ymax)^2;
 % in the Poisson distribution section, the input definition for e and this
 % output.
 %
-% this code now adds e (an input *variance* rather than std deviation) to
-% eout if it exists rather than if it does not.
+% adds e (the input variance) to eout if it exists 
+% (it may not,see @sqw/nosify)
 if exist('e','var') && ~isempty(e)
     if isequal(size(e),size(eout))
         eout=eout+e;

--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -17,70 +17,63 @@ function [yout,eout] = noisify (y,e,varargin)
 %           Add noise with Poisson distribution, where the mean value at
 %           a point is the value y.
 %
-%   >> [yout, eout] = noisify(y,e,[factor,]'maxval',maxval)
+%   >> [yout, eout] = noisify(y,e,[factor,]'maximum_value',maxval)
 %           Add noise with Gaussian distribution, calculating the standard
 %           deviation by an externally provided maximum y value.
-%           The max value is preceded by a keyword string 'maxval'.
+%           The max value is preceded by a keyword string 'maximum_value'.
 %           Typically this value will be the overall maximum value if the
 %           data is processed page by page and the maximum must be
 %           extracted before this processing.
 %           Omitting factor will use the default value 0.1.
 %
-%   If no input errors, e, just set e=[]
+%   If no input errors, e, just set e=[]. Note that eout will be created
+%   regardless of whether e is present, so the first overload output is
+%   probably incomplete.
+
+% deal with optional arguments
+is_poisson= false;
+fac = 0.1;
+if nargin>=2
+    p = inputParser;
+    addRequired(p,'y');   % y compulsory
+    addRequired(p,'e');   % e compulsory if any of remaining optional/parameter arguments present
+    numeric_or_string = @(x) isnumeric(x) || ischar(x)
+    addOptional(p,'dist_or_factor',fac, numeric_or_string);  % fac (numeric) or distribution ('poisson') optional, default to fac=0.1
+    addParameter(p,'maximum_value',-999,@isnumeric);  % ymax, as parameter 'maximum_value'. Default to highly visible negative value.
+    parse(p,y,e,varargin{:});
+
+    % pick up signal max value as either default or input
+    ymax = p.Results.maximum_value;
+
+    % vary if 'poisson' or fac present
+    if isnumeric(p.Results.dist_or_factor)
+        fac = p.Results.dist_or_factor;
+    elseif p.Results.dist_or_factor == 'poisson'
+        is_poisson = true;
+    else
+        error('3rd argument cannot be interpreted as a Gaussian factor or legal probability distribution')
+    end
+end
 
 % Use Poisson distribution and ignore other arguments
-if nargin==3 && ischar(varargin{1}) && is_stringmatchi(varargin{1},'poisson')
-        yout=zeros(size(y));
-        for i=1:numel(y)
-            yout(i)=randpoisson(abs(y(i)));
-        end
-        eout=abs(y);  % the input y is the mean and variance of the Poisson distribution
-        return % RETURN here as the poisson route is independent of the other argument options
-end
-
-% If not return, use normal distribution with or without an input maximum signal:
-default_fac = 0.1;
-ymax = [];
-fac = default_fac;
-if nargin>=3
-    % Check for maxval keyword and set ymax, else calc ymax locally below
-    pos = find(strcmp(varargin,'maxval')==1);
-    if ~isempty(pos) && pos<size(varargin,2)
-        ymax = varargin{pos+1};
-    else
-        error('Could not find maxval value arg with maxval specified')
+if is_poisson
+    yout=zeros(size(y));
+    for i=1:numel(y)
+        yout(i)=randpoisson(abs(y(i)));
     end
-    % Check for input of fac as 3rd arg, set to default otherwise
-    if isempty(pos) || pos ~= 1
-        if isnumeric(varargin{1}) && isscalar(varargin{1})
-            fac = varargin{1};
-        else
-            error('Noise as fraction of peak signal must be real scalar')
-        end
-    else
-        fac = default_fac;
+    eout=abs(y);  % the input y is the mean and variance of the Poisson distribution
+else
+    % if ymax was not set by an argument, set from max of |y|
+    if ymax < 0.0
+        ymax = max(abs(y(:)));
     end
+
+    % make noise dy and add to y for output; make error bar for noise    
+    dy=(fac*ymax)*randn(size(y));   % st. dev. of randn is sigma=1
+    yout=y+dy;
+    eout=ones(size(y))*(fac*ymax)^2;
 end
 
-% Check for any other distribution in arg #3
-if nargin>=3 && ischar(varargin{1}) && ~is_stringmatchi(varargin{1},'maxval')
-    error('Unrecognised random sampling distribution')
-end
-
-% if ymax was not set by an argument, set from max of |y|
-if isempty(ymax)
-    ymax = max(abs(y(:)));
-end
-    
-% make noise dy and add to y for output; make error bar for noise    
-dy=(fac*ymax)*randn(size(y));   % st. dev. of randn is sigma=1
-yout=y+dy;
-eout=ones(size(y))*(fac*ymax)^2;
-
-% this code now outputs a variance to be consistent between the use of eout
-% in the Poisson distribution section, the input definition for e and this
-% output.
-%
 % adds e (the input variance) to eout if it exists 
 % (it may not,see @sqw/nosify)
 if exist('e','var') && ~isempty(e)

--- a/herbert_core/utilities/maths/noisify.m
+++ b/herbert_core/utilities/maths/noisify.m
@@ -1,4 +1,4 @@
-function [yout,eout] = noisify (y,e,varargin)
+function [yout,eout] = noisify(y,e,varargin)
 % Adds noise to y values and associated error bars. The arrays y, e must
 % have same size. y is the signal and e is its variance.
 %
@@ -31,28 +31,11 @@ function [yout,eout] = noisify (y,e,varargin)
 %   probably incomplete.
 
 % deal with optional arguments
-is_poisson= false;
+is_poisson = false;
 fac = 0.1;
-if nargin>=2
-    p = inputParser;
-    addRequired(p,'y');   % y compulsory
-    addRequired(p,'e');   % e compulsory if any of remaining optional/parameter arguments present
-    numeric_or_string = @(x) isnumeric(x) || ischar(x);
-    addOptional(p,'dist_or_factor',fac, numeric_or_string);  % fac (numeric) or distribution ('poisson') optional, default to fac=0.1
-    addParameter(p,'maximum_value',-999,@isnumeric);  % ymax, as parameter 'maximum_value'. Default to highly visible negative value.
-    parse(p,y,e,varargin{:});
-
-    % pick up signal max value as either default or input
-    ymax = p.Results.maximum_value;
-
-    % vary if 'poisson' or fac present
-    if isnumeric(p.Results.dist_or_factor)
-        fac = p.Results.dist_or_factor;
-    elseif p.Results.dist_or_factor == 'poisson'
-        is_poisson = true;
-    else
-        error('3rd argument cannot be interpreted as a Gaussian factor or legal probability distribution')
-    end
+USE_LOCAL_MAX = -999; % set default ymax to distinctive negative value
+if nargin>=2 % avoids the case where the only paramemter is y; for >=2 e will not be optional
+    [fac, is_poisson, ymax] = parse_args(y, e, fac, is_poisson, USE_LOCAL_MAX, varargin{:});
 end
 
 % Use Poisson distribution and ignore other arguments
@@ -64,7 +47,7 @@ if is_poisson
     eout=abs(y);  % the input y is the mean and variance of the Poisson distribution
 else
     % if ymax was not set by an argument, set from max of |y|
-    if ymax < 0.0
+    if ymax == USE_LOCAL_MAX
         ymax = max(abs(y(:)));
     end
 
@@ -80,6 +63,29 @@ if exist('e','var') && ~isempty(e)
     if isequal(size(e),size(eout))
         eout=eout+e;
     else
-        error('Input array of error bars must have same size as input y array')
+        error('HERBERT:noisify', 'Input array of error bars must have same size as input y array')
+    end
+end
+end
+
+function [fac, is_poisson, ymax] = parse_args(y, e, fac, is_poisson, use_local_max, varargin)
+    p = inputParser;
+    addRequired(p, 'y', @isnumeric);   % y compulsory
+    addRequired(p, 'e', @isnumeric);   % e compulsory if any of remaining optional/parameter arguments present
+    numeric_or_poisson = @(x) isnumeric(x) || strcmpi(x,'poisson');
+    addOptional(p, 'dist_or_factor', fac, numeric_or_poisson);  % fac (numeric) or distribution ('poisson') optional, default to fac=0.1
+    addParameter(p,'maximum_value', use_local_max, @isnumeric);  % ymax, as parameter 'maximum_value'. Default to highly visible named negative value.
+    parse(p,y,e,varargin{:});
+
+    % pick up signal max value as either default or input
+    ymax = p.Results.maximum_value;
+
+    % vary if 'poisson' or fac present
+    if isnumeric(p.Results.dist_or_factor)
+        fac = p.Results.dist_or_factor;
+    elseif strcmpi(p.Results.dist_or_factor, 'poisson')
+        is_poisson = true;
+    else
+        error('HERBERT:noisify', '3rd argument cannot be interpreted as a Gaussian factor or legal probability distribution')
     end
 end


### PR DESCRIPTION
This PR does the following:

- it does fix #234 to correct 
    - (i) interpretation of the input e and output eout as standard deviations rather than variances - sqrts and ^2s are removed
    - (ii) isempty test on the error output processing at the end is switched to not isempty to allow correct comparison of input and output error sizes

- it also supports a fourth argument to pass a previously calculated max signal value to replace the locally calculated one. This allows a max to be calculated in a previous pass when paging is used.
    - the existing interface is unchanged
    - if the fourth argument is present, the third argument can be defaulted using a value <0.