### PR TITLE
Return RNG to previous state on create_folder cleanup

### DIFF
--- a/_test/test_mpi/job_dispatcher_common_tests.m
+++ b/_test/test_mpi/job_dispatcher_common_tests.m
@@ -34,7 +34,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
 
             % JETester specific control parameters
             old_rng_state = rng('shuffle');
-            cleanup = onCleanup(old_rng_state);
+            cleanup = onCleanup(@() rng(old_rng_state));
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt'], ...
@@ -239,7 +239,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
             old_rng_state = rng('shuffle');
-            cleanup = onCleanup(old_rng_state);
+            cleanup = onCleanup(@() rng(old_rng_state));
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);
@@ -340,7 +340,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
             old_rng_state = rng('shuffle');
-            cleanup = onCleanup(old_rng_state);
+            cleanup = onCleanup(@() rng(old_rng_state));
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);
@@ -409,7 +409,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
             old_rng_state = rng('shuffle');
-            cleanup = onCleanup(old_rng_state);
+            cleanup = onCleanup(@() rng(old_rng_state));
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);

--- a/_test/test_mpi/job_dispatcher_common_tests.m
+++ b/_test/test_mpi/job_dispatcher_common_tests.m
@@ -27,26 +27,27 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                     end
                 end
             end
-            
+
             display_fail_log = false;
-            
+
             % overloaded to empty test -- nothing new for this JD
-            
+
             % JETester specific control parameters
-            rng('shuffle');
+            old_rng_state = rng('shuffle');
+            cleanup = onCleanup(old_rng_state);
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt'], ...
                 'fail_for_labsN', 2);
-            
+
             file1 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L1_nf1.txt']);
             file2 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L2_nf1.txt']);
             file3 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L3_nf1.txt']);
             file3a = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L3_nf2.txt']);
-            
+
             files = {file1, file3, file3a};
             co = onCleanup(@()(my_delete(files{:})));
-            
+
             jd = JobDispatcher(['test_job_', obj.cluster_name, '_fail_restart']);
             disp('*********************************************************')
             disp('**************FAIL-1 Lab2 Fails *************************')
@@ -60,8 +61,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             function is = is_err(x)
                 if isa(x, 'MException') || isa(x, 'ParallelException')
                     is = true;
@@ -75,10 +76,10 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 end
             end
             assertTrue(n_failed > 0);
-            
+
             fin = cellfun(@is_err, outputs);
             assertTrue(sum(fin) >= 1)
-            
+
             if isstruct(outputs{2})
                 ok = strcmp(outputs{2}.fail_reason,...
                     'Task N2 failed at jobExecutor: JETester. Reason: simulated failure for lab N 2');
@@ -93,7 +94,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 end
                 assertTrue(ok,['Invalid result:', outputs{2}.message]);
             end
-            
+
             % file may exist or may not -- depending on relation between
             % speed of workers
             co = onCleanup(@()(my_delete(file3, file3a)));
@@ -101,7 +102,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             disp('*********************************************************')
             disp('**************FAIL-2 Lab1 Fails *************************')
             disp('*********************************************************')
-            
+
             %2)----------------------------------------------------------
             [outputs, n_failed, ~, jd] = jd.restart_job('JETester', common_param, 4, true, true, 1);
             if display_fail_log || numel(outputs) ~=3
@@ -111,18 +112,18 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             assertTrue(n_failed >= 1);
             fin = cellfun(@is_err, outputs);
             assertTrue(sum(fin) >= 1)
-            
+
             clear co;
             % check long job cancelled due to part of the job failed
             disp('*********************************************************')
             disp('**************FAIL 3 Lab1-2 Fail -- long job*************')
             disp('*********************************************************')
-            
+
             %3)----------------------------------------------------------
             [outputs, n_failed, ~, jd] = jd.restart_job('JETester', common_param, 99, true, true, 1);
             if display_fail_log || numel(outputs) ~=3
@@ -132,12 +133,12 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             assertTrue(n_failed > 0);
             fin = cellfun(@is_err, outputs);
             assertTrue(sum(fin) >= 1)
-            
+
             for i = 1:33
                 fileN = fullfile(obj.working_dir, sprintf('test_JD_%s%sL3_nf%d.txt', obj.cluster_name,FE, i));
                 if exist(fileN, 'file') == 2
@@ -150,8 +151,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             disp('*********************************************************')
             disp('**************FAIL 4 Lab-3 Fail, long job****************')
             disp('*********************************************************')
-            
-            
+
+
             %4)----------------------------------------------------------
             [outputs, n_failed, ~, jd] = jd.restart_job('JETester', common_param, 99, true, true, 1);
             if display_fail_log || numel(outputs) ~=3
@@ -161,13 +162,13 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             assertTrue(n_failed >= 1);
             fin = cellfun(@is_err, outputs);
             assertTrue(sum(fin) >= 1)
-            
-            
+
+
             for i = 1:33
                 fileN1 = fullfile(obj.working_dir, sprintf('test_JD_%s%sL1_nf%d.txt', obj.cluster_name,FE, i));
                 if exist(fileN1, 'file') == 2
@@ -185,17 +186,17 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                     end
                 end
             end
-            
+
             common_param = rmfield(common_param, 'fail_for_labsN');
             files = {file1, file2, file3, file3a};
             co = onCleanup(@()(my_delete(files{:})));
-            
+
             disp('*********************************************************')
             disp('**************RUN 5 Should finish successfully **********')
             disp('*********************************************************')
-            
-            
-            
+
+
+
             %5)----------------------------------------------------------
             [outputs, n_failed,~,jd] = jd.restart_job('JETester', common_param, 4, true, false, 1);
             if n_failed>0
@@ -208,15 +209,15 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             assertEqual(n_failed, 0);
             assertEqual(numel(outputs), 3);
-            
+
             assertEqual(outputs{1}, 'Job 1 generated 1 files');
             assertEqual(outputs{2}, 'Job 2 generated 1 files');
             assertEqual(outputs{3}, 'Job 3 generated 2 files');
-            
+
             assertTrue(exist(file1, 'file') == 2);
             assertTrue(exist(file2, 'file') == 2);
             assertTrue(exist(file3, 'file') == 2);
@@ -237,7 +238,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             display_ouptut = hc.log_level>0;
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
-            rng('shuffle');
+            old_rng_state = rng('shuffle');
+            cleanup = onCleanup(old_rng_state);
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);
@@ -246,10 +248,10 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             file3 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L3_nf1.txt']);
             files = {file1, file2, file3};
             co = onCleanup(@()(delete(files{:})));
-            
+
             jd = JobDispatcher(['test_', obj.cluster_name, '_3workers']);
             n_workers = 3;
-            
+
             [outputs, n_failed,~,jd] = jd.start_job('JETester', common_param, 3, true, n_workers, true, 1);
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,3)
@@ -258,7 +260,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 3 workers successful run : failed  outputs :')
                 disp(outputs);
             end
-            
+
             assertEqual(n_failed, 0);
             assertEqual(numel(outputs), 3);
             assertEqual(outputs{1}, 'Job 1 generated 1 files');
@@ -267,7 +269,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             assertTrue(exist(file1, 'file') == 2);
             assertTrue(exist(file2, 'file') == 2);
             assertTrue(exist(file3, 'file') == 2);
-            
+
             common_param = struct('data_buffer_size',10000000);
             n_steps = 30;
             [outputs, n_failed,~,jd] = jd.restart_job('JETesterWithData',...
@@ -275,7 +277,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,3)
             end
-            
+
             assertEqual(n_failed, 0);
             for i=1:numel(outputs)
                 if display_ouptut
@@ -283,15 +285,15 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 end
                 assertEqualToTol(outputs{i},(n_steps+1)*n_steps/2);
             end
-            
+
             n_steps = 3;
             [outputs, n_failed,~,jd] = jd.restart_job('JETesterWithData',...
                 common_param,n_steps*n_workers,true, true, 1);
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,3)
             end
-            
-            
+
+
             assertEqual(n_failed, 0);
             disp('*********** JETesterWithData: outputs: ')
             for i=1:numel(outputs)
@@ -300,8 +302,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 end
                 assertEqualToTol(outputs{i},(n_steps+1)*n_steps/2);
             end
-            
-            
+
+
             n_steps = 30;
             common_param = struct('data_buffer_size',10000000);
             [outputs, n_failed] = jd.restart_job('JETesterSendData',...
@@ -309,8 +311,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,3)
             end
-            
-            
+
+
             assertEqual(n_failed, 0);
             disp('*********** JETesterWithData: outputs: ')
             for i=1:numel(outputs)
@@ -334,24 +336,25 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             clear mex;
             hc = herbert_config;
             display_ouptut = hc.log_level>0;
-            
+
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
-            rng('shuffle');
+            old_rng_state = rng('shuffle');
+            cleanup = onCleanup(old_rng_state);
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);
-            
+
             file1 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L1_nf1.txt']);
             file2 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L2_nf1.txt']);
             file3 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE, 'L2_nf2.txt']);
             files = {file1, file2, file3};
             co = onCleanup(@()(delete(files{:})));
-            
+
             jd = JobDispatcher(['test_', obj.cluster_name, '_2workers']);
             n_workers = 2;
-            
-            
+
+
             [outputs, n_failed,~,jd] = jd.start_job('JETester', common_param, 3, true, n_workers, true, 1);
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,2)
@@ -360,8 +363,8 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 disp('************* 2 workers run : failed  outputs :')
                 disp(outputs);
             end
-            
-            
+
+
             assertEqual(n_failed, 0);
             assertEqual(numel(outputs), 2);
             assertEqual(outputs{1}, 'Job 1 generated 1 files');
@@ -378,7 +381,7 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,2)
             end
-            
+
             assertEqual(n_failed, 0);
             for i=1:numel(outputs)
                 if display_ouptut
@@ -386,11 +389,11 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 end
                 assertEqualToTol(outputs{i},(n_steps+1)*n_steps/2);
             end
-            
-            
+
+
         end
         %
-        
+
         %
         function test_job_with_logs_worker(obj, varargin)
             if obj.ignore_test
@@ -402,27 +405,28 @@ classdef job_dispatcher_common_tests < MPI_Test_Common
                 obj.setUp();
                 clob0 = onCleanup(@()tearDown(obj));
             end
-            
+
             % overloaded to empty test -- nothing new for this JD
             % JETester specific control parameters
-            rng('shuffle');
+            old_rng_state = rng('shuffle');
+            cleanup = onCleanup(old_rng_state);
             FE = char(randi(25,1,5) + 64);
             common_param = struct('filepath', obj.working_dir, ...
                 'filename_template', ['test_JD_', obj.cluster_name,FE,'L%d_nf%d.txt']);
-            
+
             file1 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE,'L1_nf1.txt']);
             file2 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE,'L1_nf2.txt']);
             file3 = fullfile(obj.working_dir, ['test_JD_', obj.cluster_name,FE,'L1_nf3.txt']);
             files = {file1, file2, file3};
             co = onCleanup(@()(delete(files{:})));
-            
+
             jd = JobDispatcher(['test_', obj.cluster_name, '_1worker']);
-            
+
             [outputs, n_failed] = jd.start_job('JETester', common_param, 3, true, 1, false, 1);
             if n_failed>0
                 jd.display_fail_job_results(outputs, n_failed,1)
             end
-            
+
             assertEqual(n_failed, 0);
             assertEqual(numel(outputs), 1);
             assertEqual(outputs{1}, 'Job 1 generated 3 files');

--- a/herbert_core/classes/instrument_classes/instrument/@IX_mod_shape_mono/private/moments_.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_mod_shape_mono/private/moments_.m
@@ -147,8 +147,8 @@ end
 
 % =================================================================================================
 function [t_cov,t_av] = moments_2D (obj, alf)
-% General case of finite non-zero widths of moderator, shaping and 
-% monochromating choppers. Have a two-dimensional integral to perform, which 
+% General case of finite non-zero widths of moderator, shaping and
+% monochromating choppers. Have a two-dimensional integral to perform, which
 % can be pathological in the case of markedly different widths for the
 % different components.
 % For this reason, there are different regimes which use different methods
@@ -175,32 +175,32 @@ if (alf*t_m_av) > fac*thi_shape
     % Zeroth moment
     area = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [0,0])), tlo_shape, thi_shape, tlo_mono, thi_mono);
-    
+
     % First moments
     t_av = zeros(1,2);
     t_av(1) = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [1,0])), tlo_shape, thi_shape, tlo_mono, thi_mono) / area;
-    
+
     t_av(2) = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [0,1])), tlo_shape, thi_shape, tlo_mono, thi_mono) / area;
-    
+
     % Second moments
     t_cov = zeros(2,2);
     t_cov(1,1) = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [2,0])), tlo_shape, thi_shape, tlo_mono, thi_mono) / area;
-    
+
     t_cov(1,2) = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [1,1])), tlo_shape, thi_shape, tlo_mono, thi_mono) / area;
-    
+
     t_cov(2,2) = integral2 (@(x,y)(fun_shaped(x, y, moderator, shaping_chopper, mono_chopper,...
         alf, t_m_offset, [0,2])), tlo_shape, thi_shape, tlo_mono, thi_mono) / area;
-        
+
     % Correct covariance matrix for non-zero first moments
     t_cov(1,1) = t_cov(1,1) - t_av(1)^2;
     t_cov(1,2) = t_cov(1,2) - t_av(1)*t_av(2);
     t_cov(2,2) = t_cov(2,2) - t_av(2)^2;
     t_cov(2,1) = t_cov(1,2);
-    
+
 else
     % Random sampling with 10^6 points seems to get the covariance to about 0.5%
     % and seems to be very robust, unlike using the Matlab functions integral
@@ -208,11 +208,10 @@ else
     % cases of widely different widths.
     % For reproducibility, reset the seed for random number generation, but
     % reset to incoming state afterwards.
-    npnt = 1e6;     
-    state = rng;        % get current state of erandom number generators
-    rng(0,'twister');   % set particular state
+    npnt = 1e6;
+    old_rng_state = rng(0,'twister');   % set particular state
+    cleanup = onCleanup(@() rng(old_rng_state));
     X = obj.rand([npnt,1]);
-    rng(state);         % return to original state
     t_cov = cov(X');
     t_av = mean(X,2)';
 end

--- a/herbert_core/utilities/misc/try_to_create_folder.m
+++ b/herbert_core/utilities/misc/try_to_create_folder.m
@@ -29,7 +29,8 @@ if ~exist(folder_path,'dir')
         pause(0.1);
     end
 else
-    rng('shuffle','simdTwister');
+    old_rng_state = rng('shuffle', 'simdTwister');
+    cleanup = onCleanup(@() rng(old_rng_state));
     test_path = fullfile(folder_path,['folder_twa_',ext,char(randi(25,1,10) + 64)]);
     [success, mess] = mkdir(test_path);
     if success


### PR DESCRIPTION
Matlab's RNG state was being overwritten in `try_to_create_folder` which was throwing off some of our tests that use random number generation. We should also not be overwriting the RNG state of users.

I've added an `onCleanup` to reset the RNG's state.

Fixes #238
Fixes https://github.com/pace-neutrons/Horace/issues/385