### PR TITLE
round-off detector parameters

### DIFF
--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
@@ -54,6 +54,10 @@ if ~use_mex
 end
 
 par(3,:) = -par(3,:);
+% round-off parameters to 5 significant digits for consistency
+% as the real accuracy is even lower but different OS interpret
+% missing digits differently
+par = round(par,5);
 
 
 
@@ -62,7 +66,7 @@ function par=get_par_matlab(filename)
 % Load data from ASCII Tobyfit .par file using matlab
 
 fid=fopen(filename,'rt');
-if fid==-1,
+if fid==-1
     error('A_LOADER:get_par_matlab','Error opening file %s\n',filename);
 end
 

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx.m
@@ -58,6 +58,11 @@ if ~use_mex
    [ncol,ndet]=size(phx);
 end
 
+% round-off parameters to 5 significant digits for consistency
+% as the real accuracy is even lower but different OS interpret
+% missing digits differently
+phx = round(phx,5);
+
 group=unique(round(phx(6,:)));
 if numel(group)==1      % all group numbers were the same (when rounded to the nearest integer)
     phx(6,:) =1:ndet;

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx_as_par.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx_as_par.m
@@ -52,10 +52,13 @@ end
 if ~use_mex
    phx=get_phx_matlab(filename);
 end
+
 % convert phx to par (not implemented)
-par = phx;
-
-
+%
+% round-off parameters to 5 significant digits for consistency
+% as the real accuracy is even lower but different OS interpret
+% missing digits differently
+par  = round(phx,5);
 
 function phx= get_phx_matlab(file_tmp)
 % Read file (use matlab)

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_phx_or_par_private.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_phx_or_par_private.m
@@ -17,9 +17,6 @@ function [det,obj]=load_phx_or_par_private(obj,return_array,force_reload,getphx,
 %                   full filename in this structure coincides with the one,
 %                   provided for file to load from.
 %
-%
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
-%
 if ~isempty(obj.det_par_) &&(~force_reload)
     sample = obj.par_file_name;
     [par_path,par_file,pext] = fileparts(sample);


### PR DESCRIPTION
Round-off all detector parameters read from ASCII files to 5 significant digits -- I think its pretty simple change