### PR TITLE
truncate asciipar

### DIFF
--- a/_test/test_data_loaders/test_asciipar_loader.m
+++ b/_test/test_data_loaders/test_asciipar_loader.m
@@ -302,10 +302,8 @@ classdef test_asciipar_loader< TestCase
             assertElementsAlmostEqual(det(2,:),detp(2,:),'relative',1.e-4);
             assertElementsAlmostEqual(det(3,:),detp(3,:),'relative',1.e-4);
             assertElementsAlmostEqual(det(4,:),detp(4,:),'relative',1.e-2);
-            assertElementsAlmostEqual(det(5,:),detp(5,:),'relative',1.e-2);
-            
-        end
-        
+            assertElementsAlmostEqual(det(5,:),detp(5,:),'relative',1.e-2);            
+        end 
     end
 end
 

--- a/_test/test_data_loaders/test_loader_ascii.m
+++ b/_test/test_data_loaders/test_loader_ascii.m
@@ -4,7 +4,7 @@ classdef test_loader_ascii< TestCase
         matlab_warning;
         test_data_path;
         test_par_file = 'demo_par.par';
-        EXPECTED_DET_NUM = 28160        
+        EXPECTED_DET_NUM = 28160
     end
     methods
         %
@@ -21,6 +21,7 @@ classdef test_loader_ascii< TestCase
             set(herbert_config,'log_level',-1,'-buffer');
             obj.matlab_warning = warning ('off','all');
         end
+        %
         function obj=tearDown(obj)
             set(herbert_config,'log_level',obj.log_level,'-buffer');
             warning (obj.matlab_warning);
@@ -124,6 +125,7 @@ classdef test_loader_ascii< TestCase
             assertTrue(~isempty(rin.det_par));
             assertTrue(isempty(rin.par_file_name));
         end
+        %
         function test_get_run_info_wrong_par(obj)
             spe_file  = fullfile(obj.test_data_path,'spe_info_correspondent2demo_par.spe');
             wrong_par = fullfile(obj.test_data_path,'wrong_par.PAR');
@@ -133,6 +135,7 @@ classdef test_loader_ascii< TestCase
             %f = @()get__info(loader);
             assertExceptionThrown(f,'ASCIIPAR_LOADER:invalid_argument');
         end
+        %
         function test_get_run_info_wrong_spe(obj)
             wrong_spe = fullfile(obj.test_data_path,'spe_wrong.spe');
             wrong_par = fullfile(obj.test_data_path,obj.test_par_file);
@@ -140,6 +143,7 @@ classdef test_loader_ascii< TestCase
             f =@()loader_ascii(wrong_spe,wrong_par);
             assertExceptionThrown(f,'LOADER_ASCII:invalid_argument');
         end
+        %
         function test_get_run_info_inconsistent2spe(obj)
             inconsistent_spe = fullfile(obj.test_data_path,'spe_info_inconsistent2demo_par.spe');
             demo_par = fullfile(obj.test_data_path,obj.test_par_file);
@@ -150,6 +154,7 @@ classdef test_loader_ascii< TestCase
             % inconsistent spe and par files
             assertExceptionThrown(f,'A_LOADER:runtime_error');
         end
+        %
         function test_get_run_info_OK(obj)
             SPE_file=fullfile(obj.test_data_path,'spe_info_correspondent2demo_par.spe');
             PAR_file=fullfile(obj.test_data_path,obj.test_par_file);
@@ -176,6 +181,7 @@ classdef test_loader_ascii< TestCase
             assertEqual(mask(1:2,1),logical(ones(2,1)))
             assertEqual(mask(:,5),logical(ones(30,1)));
         end
+        %
         function test_get_data_info(obj)
             spe_file_name = fullfile(obj.test_data_path,'MAP10001.spe');
             [ndet,en,file_name]=loader_ascii.get_data_info(spe_file_name);
@@ -184,7 +190,7 @@ classdef test_loader_ascii< TestCase
             assertEqual(obj.EXPECTED_DET_NUM,ndet);
             assertEqual(spe_file_name,file_name);
         end
-        
+        %
         function test_can_load_and_init(obj)
             spe_file_name = fullfile(obj.test_data_path,'MAP10001.spe');
             other_file_name = fullfile(obj.test_data_path,'MAP11014.nxspe');
@@ -215,7 +221,7 @@ classdef test_loader_ascii< TestCase
             
             assertEqual(en,en1);
             assertEqual(ndet,ndet1);
-        
+            
         end
         function test_an_load_and_init_all(obj)
             spe_file_name = fullfile(obj.test_data_path,'MAP10001.spe');
@@ -245,14 +251,14 @@ classdef test_loader_ascii< TestCase
             assertEqual(31,numel(en));
             
         end
-        
-        
+        %
         function test_get_file_extension(obj)
             fext=loader_ascii.get_file_extension();
             
             assertEqual(fext,'.spe');
             assertEqual(4,numel(fext));
         end
+        %
         function test_is_loader_defined(obj)
             spe_file_name = fullfile(obj.test_data_path,'MAP10001.spe');
             par_file_name =fullfile(obj.test_data_path,obj.test_par_file);
@@ -274,8 +280,34 @@ classdef test_loader_ascii< TestCase
             [ok,mess]=la.is_loader_valid();
             assertEqual(1,ok);
             assertEqual('',mess);
-        end              
-        
-        
+        end
+        function test_mex_nomex(obj)
+            if isempty(which('get_ascii_file'))
+                warning('test_mex_nomex:disabled',...
+                    ' no  get_ascii_file.mex found so the test has been disabled')
+            end
+            hc = herbert_config;
+            config_data = hc.get_data_to_store();
+            clob = onCleanup(@()set(hc,config_data));
+            
+            
+            spe_file = fullfile(obj.test_data_path,'MAP10001.spe');
+            par_file = fullfile(obj.test_data_path,obj.test_par_file);
+            ld = loader_ascii(spe_file,par_file);
+            
+            hc.use_mex = true;
+            [Smex,Emex,enMex] = ld.load_data();
+            detMex = ld.load_par('-array');
+            
+            hc.use_mex = false;
+            [Snom,Enom,enNom] = ld.load_data();
+            detNom = ld.load_par('-array');
+            
+            assertEqual(Smex,Snom);
+            assertEqual(Emex,Enom);
+            assertEqual(enMex,enNom);
+            assertEqual(detMex,detNom);
+            
+        end
     end
 end

--- a/herbert_core/classes/data_loaders/@a_loader/a_loader.m
+++ b/herbert_core/classes/data_loaders/@a_loader/a_loader.m
@@ -19,8 +19,6 @@ classdef a_loader < a_detpar_loader_interface
     % loading from file)
     %
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
-    %
     % the properties common for all data loaders.
     properties(Dependent)
         % number of detectors in par file or in data file (should be

--- a/herbert_core/classes/data_loaders/@asciipar_loader/asciipar_loader.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/asciipar_loader.m
@@ -11,7 +11,6 @@ classdef asciipar_loader < a_detpar_loader_interface
     % both with ASCII par files and the detector information containing in
     % the main data file (if the later intended to be used)
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
     %
     % the properties common for all data loaders.
     %

--- a/herbert_core/classes/data_loaders/@asciipar_loader/asciipar_loader.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/asciipar_loader.m
@@ -26,6 +26,12 @@ classdef asciipar_loader < a_detpar_loader_interface
         % The data fields an ascii par loader defines
         par_can_define_ = {'det_par','n_det_in_par'};
     end
+    properties(Constant)
+        % when read ascii parameters, keep the specified number of digits after
+        % decimal point to obtain consitent results on different operating
+        % systen
+        ASCII_PARAM_ACCURACY = 4;
+    end
     methods
         % constructor;
         function this=asciipar_loader(varargin)

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
@@ -1,6 +1,13 @@
-function par=load_ASCII_par(filename)
+function par=load_ASCII_par(filename,accuracy)
 % Load data from ASCII Tobyfit .par file
 %   >> par = load_ASCII_par(filename)
+%   >> par = load_ASCII_par(filename,accuracy)
+% Inputs:
+% filename -- name of the par file to read
+% accuracy -- if provided, the number of digits to keep
+%             after decimal point. If not provided, the
+%             accuracy is equal to asciipar_loader.ASCII_PARAM_ACCURACY
+%
 %
 % data has following fields:
 %
@@ -25,6 +32,9 @@ function par=load_ASCII_par(filename)
 if ~exist('filename','var')
     help load_ASCII_par;
     return
+end
+if ~exist('accuracy','var')
+    accuracy = asciipar_loader.ASCII_PARAM_ACCURACY;
 end
 % Remove blanks from beginning and end of filename
 filename=strtrim(filename);
@@ -54,10 +64,10 @@ if ~use_mex
 end
 
 par(3,:) = -par(3,:);
-% round-off parameters to 4 digits after dot for consistency
+% round-off parameters to 'accuracy' digits after dot for consistency
 % as the real accuracy is even lower but different OS interpret
 % missing digits differently
-par = round(par,4);
+par = round(par,accuracy);
 
 
 

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_par.m
@@ -54,10 +54,10 @@ if ~use_mex
 end
 
 par(3,:) = -par(3,:);
-% round-off parameters to 5 significant digits for consistency
+% round-off parameters to 4 digits after dot for consistency
 % as the real accuracy is even lower but different OS interpret
 % missing digits differently
-par = round(par,5);
+par = round(par,4);
 
 
 

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx.m
@@ -1,6 +1,12 @@
-function phx=load_ASCII_phx(filename)
+function phx=load_ASCII_phx(filename,accuracy)
 % Load data from ASCII mslice .phx file
-%   >> par = load_ASCII_phx_as_par(filename)
+%   >> par = load_ASCII_phx(filename)
+%   >> par = load_ASCII_phx(filename,accuracy)
+% Inputs:
+% filename -- name of the par file to read
+% accuracy -- if provided, the number of digits to keep
+%             after decimal point. If not provided, the
+%             accuracy is equal to asciipar_loader.ASCII_PARAM_ACCURACY
 %
 % data has following fields:
 %
@@ -29,6 +35,9 @@ if ~exist('filename','var')
     help get_par;
     return
 end
+if ~exist('accuracy','var')
+    accuracy = asciipar_loader.ASCII_PARAM_ACCURACY;
+end
 
 filename=strtrim(filename);
 
@@ -54,14 +63,14 @@ if use_mex
 end
 
 if ~use_mex
-   phx=get_phx_matlab(filename);
-   [ncol,ndet]=size(phx);
+    phx=get_phx_matlab(filename);
+    [ncol,ndet]=size(phx);
 end
 
-% round-off parameters to 5 significant digits for consistency
+% round-off parameters to 'accuracy' digits after decimal point for consistency
 % as the real accuracy is even lower but different OS interpret
 % missing digits differently
-phx = round(phx,5);
+phx = round(phx,accuracy);
 
 group=unique(round(phx(6,:)));
 if numel(group)==1      % all group numbers were the same (when rounded to the nearest integer)
@@ -95,7 +104,8 @@ end
 phx=fscanf(fid,'%f');
 fclose(fid);
 if numel(phx)~=ndet*7
-    error('A_LOADER:io_error',['File determined to have ',num2str(ndet),' detectors, but contents are inconsistent with a .phx file']);
+    error('A_LOADER:io_error',...
+        ['File determined to have ',num2str(ndet),' detectors, but contents are inconsistent with a .phx file']);
 end
 phx = reshape(phx,7,ndet);
 % exclude 2-nd row to have the same format as  par
@@ -106,5 +116,5 @@ phx=[phx(1,:);phx(3:7,:)];
 %     phx.azim=arr(4,:);
 %     phx.dphi=arr(5,:);
 %     phx.danght=arr(6,:);
-    
+
 

--- a/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx_as_par.m
+++ b/herbert_core/classes/data_loaders/@asciipar_loader/private/load_ASCII_phx_as_par.m
@@ -1,7 +1,14 @@
-function par=load_ASCII_phx_as_par(filename)
+function par=load_ASCII_phx_as_par(filename,accuracy)
 % Load data from ASCII mslice .phx file
 %   >> par = load_ASCII_phx_as_par(filename)
+%   >> par = load_ASCII_phx_as_par(filename,accuracy)
 %
+% Inputs:
+% filename -- name of the par file to read
+% accuracy -- if provided, the number of digits to keep
+%             after decimal point. If not provided, the
+%             accuracy is equal to asciipar_loader.ASCII_PARAM_ACCURACY
+
 % data has following fields:
 %
 %     par(6,ndet)   contents of array
@@ -29,6 +36,10 @@ if ~exist('filename','var')
     help get_par;
     return
 end
+if ~exist('accuracy','var')
+    accuracy = asciipar_loader.ASCII_PARAM_ACCURACY;
+end
+
 
 filename=strtrim(filename);
 
@@ -50,15 +61,16 @@ if use_mex
 end
 
 if ~use_mex
-   phx=get_phx_matlab(filename);
+    phx=get_phx_matlab(filename);
 end
 
-% convert phx to par (not implemented)
 %
-% round-off parameters to 5 significant digits for consistency
+% round-off parameters to 'accuracy' digits after decimal pointfor consistency
 % as the real accuracy is even lower but different OS interpret
 % missing digits differently
-par  = round(phx,5);
+%
+% convert phx to par (not implemented)
+par  = round(phx,accuracy);
 
 function phx= get_phx_matlab(file_tmp)
 % Read file (use matlab)
@@ -99,5 +111,5 @@ end
 %     phx.azim=arr(4,:);
 %     phx.dphi=arr(5,:);
 %     phx.danght=arr(6,:);
-    
+
 

--- a/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
+++ b/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
@@ -1,4 +1,4 @@
-function [varargout]=load_data(this,new_file_name)
+function [varargout]=load_data(obj,new_file_name)
 % Loads ASCII spe data into run_data structure
 %
 % this fucntion is the method of load_spe class
@@ -11,21 +11,21 @@ function [varargout]=load_data(this,new_file_name)
 %>>[S,ERR,en,this] = load_data(this,[new_file_name])
 %>>this            = load_data(this,[new_file_name])
 
-% $Author: Alex Buts; 20/10/2011
+% $Author: AB; 20/10/2011
 %
 
 if exist('new_file_name','var')
     if ~isa(new_file_name,'char')
         error('LOAD_ASCII:load_data','new file name has to be a string')
     end
-    this.file_name  = new_file_name;
+    obj.file_name  = new_file_name;
 else
-    if isempty(this.file_name)
+    if isempty(obj.file_name)
         error('LOAD_ASCII:load_data','input spe file is not fully defined')
     end
     
 end
-file_name  = this.file_name;
+file_name  = obj.file_name;
 
 use_mex=config_store.instance().get_value('herbert_config','use_mex');
 if use_mex
@@ -53,29 +53,30 @@ nans      = (S(:,:)<-1.e+29);
 S(nans)   = NaN;
 ERR(nans) = 0;
 
+accuracy = obj.ASCII_DATA_ACCURACY;
 % Fill output argument(s)
 if nargout == 1
     % set also all dependent on S variables
-    this.S_  =round(S,4);
-    this.ERR_=round(ERR,4);
-    this.en_ =round(en,4);
+    obj.S_  =round(S,accuracy );
+    obj.ERR_=round(ERR,accuracy );
+    obj.en_ =round(en,accuracy );
     
-    varargout{1}=this;
+    varargout{1}=obj;
 elseif nargout ==2
-    varargout{1}=round(S,4);
-    varargout{2}=round(ERR,4);
+    varargout{1}=round(S,accuracy );
+    varargout{2}=round(ERR,accuracy );
 elseif nargout == 3
-    varargout{1}=round(S,4);
-    varargout{2}=round(ERR,4);
-    varargout{3}=round(en,4);
+    varargout{1}=round(S,accuracy );
+    varargout{2}=round(ERR,accuracy );
+    varargout{3}=round(en,accuracy );
 elseif nargout == 4
-    this.S_  =round(S,4);
-    this.ERR_=round(ERR,4);
-    this.en_ =round(en,4);
+    obj.S_  =round(S,accuracy );
+    obj.ERR_=round(ERR,accuracy);
+    obj.en_ =round(en,accuracy);
     
-    varargout{1}=this.S_ ;
-    varargout{2}=this.ERR_;
-    varargout{3}=this.en_;
-    varargout{4}=this;
+    varargout{1}=obj.S_ ;
+    varargout{2}=obj.ERR_;
+    varargout{3}=obj.en_;
+    varargout{4}=obj;
 end
 

--- a/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
+++ b/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
@@ -56,26 +56,26 @@ ERR(nans) = 0;
 % Fill output argument(s)
 if nargout == 1
     % set also all dependent on S variables
-    this.S_  =S;
-    this.ERR_=ERR;
-    this.en_ =en;
+    this.S_  =round(S,5);
+    this.ERR_=round(ERR,5);
+    this.en_ =round(en,5);
     
     varargout{1}=this;
 elseif nargout ==2
-    varargout{1}=S;
-    varargout{2}=ERR;
+    varargout{1}=round(S,5);
+    varargout{2}=round(ERR,5);
 elseif nargout == 3
-    varargout{1}=S;
-    varargout{2}=ERR;
-    varargout{3}=en;
+    varargout{1}=round(S,5);
+    varargout{2}=round(ERR,5);
+    varargout{3}=round(en,5);
 elseif nargout == 4
-    this.S_  =S;
-    this.ERR_=ERR;
-    this.en_ =en;
+    this.S_  =round(S,5);
+    this.ERR_=round(ERR,5);
+    this.en_ =round(en,5);
     
-    varargout{1}=S;
-    varargout{2}=ERR;
-    varargout{3}=en;
+    varargout{1}=this.S_ ;
+    varargout{2}=this.ERR_;
+    varargout{3}=this.en_;
     varargout{4}=this;
 end
 

--- a/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
+++ b/herbert_core/classes/data_loaders/@loader_ascii/load_data.m
@@ -56,22 +56,22 @@ ERR(nans) = 0;
 % Fill output argument(s)
 if nargout == 1
     % set also all dependent on S variables
-    this.S_  =round(S,5);
-    this.ERR_=round(ERR,5);
-    this.en_ =round(en,5);
+    this.S_  =round(S,4);
+    this.ERR_=round(ERR,4);
+    this.en_ =round(en,4);
     
     varargout{1}=this;
 elseif nargout ==2
-    varargout{1}=round(S,5);
-    varargout{2}=round(ERR,5);
+    varargout{1}=round(S,4);
+    varargout{2}=round(ERR,4);
 elseif nargout == 3
-    varargout{1}=round(S,5);
-    varargout{2}=round(ERR,5);
-    varargout{3}=round(en,5);
+    varargout{1}=round(S,4);
+    varargout{2}=round(ERR,4);
+    varargout{3}=round(en,4);
 elseif nargout == 4
-    this.S_  =round(S,5);
-    this.ERR_=round(ERR,5);
-    this.en_ =round(en,5);
+    this.S_  =round(S,4);
+    this.ERR_=round(ERR,4);
+    this.en_ =round(en,4);
     
     varargout{1}=this.S_ ;
     varargout{2}=this.ERR_;

--- a/herbert_core/classes/data_loaders/@loader_ascii/loader_ascii.m
+++ b/herbert_core/classes/data_loaders/@loader_ascii/loader_ascii.m
@@ -2,9 +2,8 @@ classdef loader_ascii < a_loader
     % helper class to provide loading experiment data from
     % ASCII spe file and  ASCII par file
     %
-    % $Author: Alex Buts; 20/10/2011
+    % $Author: AB; 20/10/2011
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
     %
     
     methods(Static)

--- a/herbert_core/classes/data_loaders/@loader_ascii/loader_ascii.m
+++ b/herbert_core/classes/data_loaders/@loader_ascii/loader_ascii.m
@@ -5,6 +5,13 @@ classdef loader_ascii < a_loader
     % $Author: AB; 20/10/2011
     %
     %
+    properties(Constant)
+        % when read ascii data, keep the specified number of digits after
+        % decimal point to obtain consitent results on different operating
+        % systems
+        ASCII_DATA_ACCURACY = 4;
+    end
+    
     
     methods(Static)
         function fext=get_file_extension()
@@ -104,7 +111,7 @@ classdef loader_ascii < a_loader
             % The run_data structure fields which become defined if proper spe file is provided
             
             obj=obj@a_loader(varargin{:});
-            obj.loader_define_ ={'S','ERR','en','n_detectors'};            
+            obj.loader_define_ ={'S','ERR','en','n_detectors'};
             if exist('full_spe_file_name','var')
                 obj = obj.init(full_spe_file_name);
             else

--- a/herbert_core/classes/data_loaders/@loader_nxspe/loader_nxspe.m
+++ b/herbert_core/classes/data_loaders/@loader_nxspe/loader_nxspe.m
@@ -2,9 +2,8 @@ classdef loader_nxspe < a_loader
     %  helper class to provide loading experiment data and detectors angular
     %  positions  from NeXus nxspe file,
     %
-    % $Author: Alex Buts; 20/10/2011
+    % $Author: AB; 20/10/2011
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
     %
     properties
         % incident energy

--- a/herbert_core/classes/data_loaders/@rundata/get_rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/get_rundata.m
@@ -78,9 +78,8 @@ function [varargout] =get_rundata(this,varargin)
 %    been set before and do not have defaults, but are mentioned in the
 %    input parameters list
 
-% $Author: Alex Buts 20/10/2011
+% $Author: AB 20/10/2011
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 
 
 % possible modifiers of the data format

--- a/herbert_core/classes/data_loaders/@rundata/private/gen_runfiles_.m
+++ b/herbert_core/classes/data_loaders/@rundata/private/gen_runfiles_.m
@@ -55,8 +55,6 @@ function [runfiles,file_exist] = gen_runfiles_(name_of_class,spe_files,varargin)
 %       is used instead;
 
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
-%
 %
 %
 control_keys = {'-allow_missing'};

--- a/herbert_core/classes/data_loaders/@rundata/private/select_loader_.m
+++ b/herbert_core/classes/data_loaders/@rundata/private/select_loader_.m
@@ -16,9 +16,8 @@ function this=select_loader_(this,varargin)
 %          value -- its desired value, which may redefine the value, specified in the
 %                   correspondent spe or par file.
 %
-% $Author: Alex Buts 20/10/2011
+% $Author: AB 20/10/2011
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 %
 
 if nargin==1; return; end

--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -18,8 +18,6 @@ classdef rundata
     % do not have default, the method get_rundata will fail
     %
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
-    %
     properties(Dependent)
         n_detectors ;   % Number of detectors, used when dealing with masked detectors  -- will be derived
         %

--- a/herbert_core/classes/data_loaders/loaders_factory.m
+++ b/herbert_core/classes/data_loaders/loaders_factory.m
@@ -3,7 +3,6 @@ classdef loaders_factory < handle
     % demand
     %
     %
-    % $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
     %
     
     


### PR DESCRIPTION
Better and more consistent implementation of the asciipar truncation with the purpose of producing consistent results on any OS with any code