### PR TITLE
Do not use Groovy interpolation for Jenkins credentials

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -123,7 +123,7 @@ def post_github_status(String state, String message) {
           variable: 'api_token')]) {
         if (isUnix()) {
           sh """
-            curl -H "Authorization: token ${api_token}" \
+            curl -H "Authorization: token \${api_token}" \
               --request POST \
               --data '{"state": "${state}", \
                   "description": "${message}", \
@@ -142,7 +142,7 @@ def post_github_status(String state, String message) {
               "context" = "$JOB_BASE_NAME"}
 
             Invoke-RestMethod -URI "$PR_STATUSES_URL" \
-              -Headers @{Authorization = "token ${api_token}"} \
+              -Headers @{Authorization = "token \$env:api_token"} \
               -Method 'POST' \
               -Body (\$payload|ConvertTo-JSON) \
               -ContentType "application/json"


### PR DESCRIPTION
If you use Groovy string interpolation when passing credentials to a
shell command, the secret will be executed in plain text on the agent.
The Jenkins logs will still mask the credentials, but any command
logging on the agent machine will leak the secret.

Using the environment variable set by the withCredentials block means
the command does not contain the secret, any command logs will only show
an environment variable was accessed.

See https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#interpolation-of-sensitive-environment-variables.

