### PR TITLE
Add run_id method to rundata class

### DIFF
--- a/_test/test_data_loaders/test_rundata.m
+++ b/_test/test_data_loaders/test_rundata.m
@@ -1,11 +1,11 @@
 classdef test_rundata< TestCase
-    %    
+    %
     properties
         log_level;
         test_data_path;
         
         test_par_file = 'demo_par.par';
-        EXPECTED_DET_NUM = 28160        
+        EXPECTED_DET_NUM = 28160
     end
     methods
         function fn=f_name(obj,short_filename)
@@ -479,6 +479,54 @@ classdef test_rundata< TestCase
             assertTrue(ok);
             assertTrue(isempty(mess));
             assertTrue(isempty(undef_list));
+        end
+        function test_run_id_present(obj)
+            source = f_name(obj,'MAP11014.nxspe');
+            rd = rundata(source );
+            id =  rd.run_id();
+            assertEqual(id,11014);
+        end
+        
+        %
+        function test_run_id_missing(obj)
+            test_file = fullfile(tmp_dir,'test_run_idNXSPE_fake.nxspe');
+            clob = onCleanup(@()delete(test_file));
+            source = f_name(obj,'MAP11014.nxspe');
+            copyfile(source,test_file);
+            
+            rd = rundata(test_file);
+            id =  rd.run_id();
+            assertEqual(id,1);
+        end
+        %
+        function test_run_id_empty(~)
+            rd = rundata();
+            id =  rd.run_id();
+            assertTrue(isempty(id));
+        end
+        %
+        function test_extract_runid_long_complex(~)
+            fname =fullfile('cycle20201','MAR1044one2oneEi4.5.nxs');
+            id = rundata.extract_id_from_filename(fname);
+            assertEqual(1044,id);
+        end
+        %
+        function test_extract_runid_complex(~)
+            fname = 'MAR1044one2oneEi4.5.nxs';
+            id = rundata.extract_id_from_filename(fname);
+            assertEqual(1044,id);
+        end
+        %
+        function test_extract_runid_simple(~)
+            fname = 'MAR1044.nxs';
+            id = rundata.extract_id_from_filename(fname);
+            assertEqual(1044,id);
+        end
+        %
+        function test_extract_runid_empty(~)
+            fname = 'nlalflalel';
+            id = rundata.extract_id_from_filename(fname);
+            assertEqual(1,id);
         end
         %
         function test_saveNXSPE_unbound(obj)

--- a/_test/test_data_loaders/test_rundata.m
+++ b/_test/test_data_loaders/test_rundata.m
@@ -92,7 +92,7 @@ classdef test_rundata< TestCase
         function test_defaultsOK_andFixed(obj)
             nn=numel(fields(rundata));
             % number of public fields by default;
-            assertEqual(14,nn);
+            assertEqual(15,nn);
         end
         function test_build_from_wrong_struct(obj)
             a.x=10;
@@ -480,10 +480,25 @@ classdef test_rundata< TestCase
             assertTrue(isempty(mess));
             assertTrue(isempty(undef_list));
         end
+        function test_run_id_set_overrides(obj)
+            source = f_name(obj,'MAP11014.nxspe');
+            rd = rundata(source );
+            assertEqual(rd.run_id,11014);
+            
+            rd.run_id = 1204;
+            assertEqual(rd.run_id,1204);
+        end
+        
+        function test_run_id_set(~)
+            rd = rundata();
+            rd.run_id = 1204;
+            assertEqual(rd.run_id,1204);
+        end
+        
         function test_run_id_present(obj)
             source = f_name(obj,'MAP11014.nxspe');
             rd = rundata(source );
-            id =  rd.run_id();
+            id =  rd.run_id;
             assertEqual(id,11014);
         end
         
@@ -495,13 +510,13 @@ classdef test_rundata< TestCase
             copyfile(source,test_file);
             
             rd = rundata(test_file);
-            id =  rd.run_id();
+            id =  rd.run_id;
             assertEqual(id,1);
         end
         %
         function test_run_id_empty(~)
             rd = rundata();
-            id =  rd.run_id();
+            id =  rd.run_id;
             assertTrue(isempty(id));
         end
         %
@@ -529,7 +544,7 @@ classdef test_rundata< TestCase
             assertEqual(1,id);
         end
         %
-        function test_saveNXSPE_unbound(obj)
+        function test_saveNXSPE_unbound(~)
             test_file = fullfile(tmp_dir,'test_saveNXSPE_unbound.nxspe');
             clob = onCleanup(@()delete(test_file));
             if exist(test_file,'file')==2

--- a/_test/test_data_loaders/test_rundata.m
+++ b/_test/test_data_loaders/test_rundata.m
@@ -100,7 +100,7 @@ classdef test_rundata< TestCase
             f = @()rundata(a);
             assertExceptionThrown(f,'RUNDATA:set_fields');
         end
-        function test_build_from_good_struct(obj)
+        function test_build_from_good_struct(~)
             a.efix=10;
             a.psi=2;
             dat=rundata(a);
@@ -108,7 +108,7 @@ classdef test_rundata< TestCase
             assertEqual(dat.lattice.psi,2);
         end
         %
-        function test_build_from_Other_rundata(obj)
+        function test_build_from_Other_rundata(~)
             ro = rundata();
             rn = rundata(ro);
             assertEqual(ro,rn);

--- a/herbert_core/classes/data_loaders/@rundata/private/convert_to_struct_.m
+++ b/herbert_core/classes/data_loaders/@rundata/private/convert_to_struct_.m
@@ -1,6 +1,6 @@
 function out_struct = convert_to_struct_(obj)
 
-%  Convert rundata object into a structure, 
+%  Convert rundata object into a structure,
 out_struct = struct();
 out_struct.class_name = class(obj);
 
@@ -9,7 +9,7 @@ fields = {'data_file_name','par_file_name','efix','emode'};
 if ~isempty(obj.loader_)
     fields_from_loader = obj.loader_.loader_define();
     in_loader = ismember(fields,fields_from_loader);
-    left_fields = fields(~in_loader);  
+    left_fields = fields(~in_loader);
 else
     left_fields = fields;
 end
@@ -18,8 +18,8 @@ end
 for nf=1:numel(left_fields)
     out_struct.(left_fields{nf}) = obj.(left_fields{nf});
 end
-if ~isempty(obj.efix_)  %incident energy here is not in the loader or have 
-                        %been set-up externally
+if ~isempty(obj.efix_)  %incident energy here is not in the loader or have
+    %been set-up externally
     out_struct.efix = obj.efix_;
 end
 if obj.is_crystal
@@ -52,4 +52,8 @@ if ~isempty(obj.sample)
 end
 if isprop(obj,'transform_sqw') && ~isempty(obj.transform_sqw)
     out_struct.transform_sqw = obj.transform_sqw;
+end
+%
+if ~isempty(obj.run_id_)
+    out_struct.run_id = obj.run_id_;
 end

--- a/herbert_core/classes/data_loaders/@rundata/private/find_run_id_.m
+++ b/herbert_core/classes/data_loaders/@rundata/private/find_run_id_.m
@@ -1,5 +1,5 @@
-function  id = run_id(obj)
-% return the index (numerical id which uniquely identifies the file) 
+function  id = find_run_id_(obj)
+% calculate and return the index (numerical id which uniquely identifies the file) 
 % of the file used as the source of the data
 %
 % Normally it picks up the numerical part of the file name

--- a/herbert_core/classes/data_loaders/@rundata/run_id.m
+++ b/herbert_core/classes/data_loaders/@rundata/run_id.m
@@ -1,0 +1,20 @@
+function  id = run_id(obj)
+% return the index (numerical id which uniquely identifies the file) 
+% of the file used as the source of the data
+%
+% Normally it picks up the numerical part of the file name
+% if the loader is undefined, the run_id is empty
+% if the file does not have numerical part, the id == 1
+% if the loader exsisit bug has empty filename, the id = 0;
+% 
+%
+if isempty(obj.loader)
+    id = [];
+    return
+end
+ld = obj.loader;
+if isempty(ld.file_name)
+    id = 0;
+    return
+end
+id = obj.extract_id_from_filename(ld.file_name);

--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -147,12 +147,26 @@ classdef rundata
             %       is used instead;
             [runfiles_list,defined]= rundata.gen_runfiles_of_type('rundata',spe_files,varargin{:});
         end
-        
+        %
         function obj = loadobj(struc)
             % build rundata from the structure, obtained from saveobj
             % method.
             obj = set_up_from_struct_(struc);
             
+        end
+        %
+        function id = extract_id_from_filename(file_name)
+            % method used to extract run id from a filename, if runnumber is
+            % present in the filename, and is first number among all other
+            % numbers
+            %
+            [~,filename] = fileparts(file_name);
+            [l_range,r_range] = regexp(filename,'\d+');
+            if isempty(l_range)
+                id = 1;
+                return;
+            end
+            id = str2double(filename(l_range(1):r_range(1)));
         end
     end
     methods(Static,Access=protected)
@@ -209,6 +223,10 @@ classdef rundata
         % of crystal or powder experiments
         [data_fields,lattice_fields] = what_fields_are_needed(this,varargin);
         %------------------------------------------------------------------
+        % return the index (numerical id which uniquely identifies the file) 
+        % of the file used as the source of the data
+        id = run_id(obj)
+        
         function this=rundata(varargin)
             % rundata class constructor
             %

--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -48,6 +48,9 @@ classdef rundata
         instrument;
         % sample model
         sample;
+        % the number (id) uniquely identyfying the particular experiment
+        % which is the source of this object data.
+        run_id;
     end
     
     properties(Constant,Access=private)
@@ -73,6 +76,8 @@ classdef rundata
         instrument_ = struct();
         % sample model holder
         sample_ = struct();
+        %
+        run_id_ = [];
     end
     methods(Static)
         function fields = main_data_fields()
@@ -223,9 +228,6 @@ classdef rundata
         % of crystal or powder experiments
         [data_fields,lattice_fields] = what_fields_are_needed(this,varargin);
         %------------------------------------------------------------------
-        % return the index (numerical id which uniquely identifies the file) 
-        % of the file used as the source of the data
-        id = run_id(obj)
         
         function this=rundata(varargin)
             % rundata class constructor
@@ -337,6 +339,24 @@ classdef rundata
             end
         end
         %
+        function id = get.run_id(obj)
+            % return the index (numerical id which uniquely identifies
+            % the experiment)
+            % of the data used as the source of the rundata
+            if ~isempty(obj.run_id_)
+                id = obj.run_id_;
+                return
+            end
+            id = find_run_id_(obj);
+        end
+        function obj = set.run_id(obj,val)
+            if ~isnumeric(val)
+                error('RUNDATA:invalid_argument',...
+                    ' run_id can be only numeric')
+            end
+            obj.run_id_ = val;
+        end
+        
         %
         function loader=get.loader(this)
             loader=this.loader_;
@@ -403,12 +423,12 @@ classdef rundata
         %---
         function obj = set.par_file_name(obj,val)
             % method to change par file on a defined loader
-            if isempty(obj.loader_) % assuming both data and parameters are taken from 
-                                    % the same nxspe file (or will be stored in
-                                    % it)
-                obj.loader_ = loader_nxspe('',val);            
+            if isempty(obj.loader_) % assuming both data and parameters are taken from
+                % the same nxspe file (or will be stored in
+                % it)
+                obj.loader_ = loader_nxspe('',val);
             else
-                obj.loader_.par_file_name = val;  
+                obj.loader_.par_file_name = val;
             end
         end
         %

--- a/herbert_core/classes/instrument_classes/@oriented_lattice/calc_proj_matrix.m
+++ b/herbert_core/classes/instrument_classes/@oriented_lattice/calc_proj_matrix.m
@@ -36,8 +36,6 @@ function [spec_to_u, u_to_rlu, spec_to_rlu] = calc_proj_matrix (obj)
 %   gl          Large goniometer arc angle (rad)
 %   gs          Small goniometer arc angle (rad)
 
-% T.G.Perring 15/6/07
-
 
 % Get matrix to convert from rlu to orthonormal frame defined by u,v; and
 b_matrix  = obj.bmatrix();       % bmat takes Vrlu to V_crystal_Cart
@@ -45,37 +43,6 @@ b_matrix  = obj.bmatrix();       % bmat takes Vrlu to V_crystal_Cart
 %u_matrix  = ub_matrix / b_matrix;         % u matrix takes V in crystal Cartesian coordinates to orthonormal frame defined by u, v
 
 obj=obj.set_rad();
-
-% Matrix to convert coordinates in orthonormal frame defined by notional directions of u, v, to
-% coordinates  in orthonormal frame defined by true directions of u, v:
-
-rot_dpsi= [cos(obj.dpsi),-sin(obj.dpsi),0;...
-    sin(obj.dpsi), cos(obj.dpsi),       0;...
-    0,             0,                   1];
-%--------------------------------------------
-rot_gl  = [cos(obj.gl),   0,     sin(obj.gl);...
-    0,                    1,     0          ;...
-    -sin(obj.gl),         0,     cos(obj.gl)];
-%--------------------------------------------
-rot_gs  = [1,             0,                0;...
-    0,             cos(obj.gs),  -sin(obj.gs);...
-    0,             sin(obj.gs),   cos(obj.gs)];
-%--------------------------------------------
-rot_om  = [cos(obj.omega),-sin(obj.omega),0;...
-    sin(obj.omega),cos(obj.omega),0;...
-    0,0,1];
-%--------------------------------------------
-corr = (rot_om * (rot_dpsi*rot_gl*rot_gs) * rot_om')';
-
-% Matrix to convert from spectrometer coordinates to orthonormal frame defined by notional directions of u, v
-cryst = [cos(obj.psi),sin(obj.psi),0; -sin(obj.psi),cos(obj.psi),0; 0,0,1];
-
-% Combine to get matrix to convert from spectrometer coordinates to crystal Cartesian coordinates
-spec_to_u = u_matrix\corr*cryst;
-
-% Matrix to convert from crystal Cartesian coordinates to r.l.u.
-u_to_rlu = inv(b_matrix);
-
-% Matrix to convert from spectrometer coordinates to r.l.u.
-spec_to_rlu = b_matrix\spec_to_u;
+[spec_to_u, u_to_rlu, spec_to_rlu] = ...
+    calc_proj_matrix(b_matrix,u_matrix, '', '', obj.psi, obj.omega, obj.dpsi, obj.gl, obj.gs);
 

--- a/herbert_core/utilities/scientific/calc_proj_matrix.m
+++ b/herbert_core/utilities/scientific/calc_proj_matrix.m
@@ -1,0 +1,83 @@
+function [spec_to_cc, u_to_rlu, spec_to_rlu] = calc_proj_matrix (var1, var2, u, v, psi, omega, dpsi, gl, gs)
+% Calculate matrix that convert momentum from coordinates in spectrometer frame to
+% projection axes defined by u1 || a*, u2 in plane of a* and b* i.e. crystal Cartesian axes
+% Allows for correction scattering plane (omega, dpsi, gl, gs) - see Tobyfit for conventions
+%
+%   >> [spec_to_u, u_to_rlu, spec_to_rlu] = ...
+%    calc_proj_matrix (alatt, angdeg, u, v, psi, omega, dpsi, gl, gs)
+% or:
+%  >>[spec_to_u, u_to_rlu, spec_to_rlu] = ...
+%    calc_proj_matrix (b_matix,u_matrix); - used as part of oriented
+%    lattice function
+%
+% Input:
+% ------
+% Either:
+%   alatt       Lattice parameters (Ang^-1)
+%   angdeg      Lattice angles (deg)
+%   u           First vector (1x3) defining scattering plane (r.l.u.)
+%   v           Second vector (1x3) defining scattering plane (r.l.u.)
+%   psi         Angle of u w.r.t. ki (rad)
+%   omega       Angle of axis of small goniometer arc w.r.t. notional u
+%   dpsi        Correction to psi (rad)
+%   gl          Large goniometer arc angle (rad)
+%   gs          Small goniometer arc angle (rad)
+% or:
+% b_matrix -- the matrix used to transform vector in hkl coordinate system
+%             into Crystal Catresian coordinate system
+% u_matrix -- transforms vector in crystal Cartesian coords to orthonormal
+%             frame defined by vectors u, v.
+%
+% Output:
+% -------
+%   spec_to_cc   Matrix (3x3)to convert momentum from coordinates in spectrometer
+%                frame to crystal Cartesian axes:
+%                    v_crystal_Cart = spec_to_cc * v_spec
+%
+%   u_to_rlu    Matrix (3x3) of crystal Cartesian axes in reciprocal lattice units
+%              i.e. u_to_rlu(:,1) first vector - u(1:3,1) r.l.u. etc.
+%              This matrix can be used to convert components of a vector in
+%              crystal Cartesian axes to r.l.u.:
+%                   v_rlu = u_to_rlu * v_crystal_Cart
+%              (Same as inv(B) in Busing and Levy convention)
+%
+%   spec_to_rlu Matrix (3x3) to convert from spectrometer coordinates to
+%              r.l.u.:
+%                   v_rlu = spec_to_rlu * v_spec
+%              (This matrix is entirely equivalent to u_to_rlu*spec_to_u)
+
+% T.G.Perring 15/6/07
+%
+
+if isempty(u) % slave mode
+    b_matrix = var1;
+    u_matrix  = var2;
+else % master mode, calculate whole transformation matrix
+    alatt = var1;
+    angdeg = var2;
+    % Get matrix to convert from rlu to orthonormal frame defined by u,v; and
+    b_matrix  = bmatrix(alatt, angdeg);       % bmat takes Vrlu to Vxtal_cart
+    ub_matrix = ubmatrix(u, v, b_matrix);     % ubmat takes Vrlu to V in orthonormal frame defined by u, v
+    u_matrix  = ub_matrix / b_matrix;         % u matrix takes V in crystal Cartesian coords to orthonormal frame defined by u, v
+end
+
+% Matrix to convert coords in orthormal frame defined by notional directions of u, v, to
+% coords in orthonormal frame defined by true directions of u, v:
+rot_dpsi= [cos(dpsi),-sin(dpsi),0; sin(dpsi),cos(dpsi),0; 0,0,1];
+rot_gl  = [cos(gl),0,sin(gl); 0,1,0; -sin(gl),0,cos(gl)];
+rot_gs  = [1,0,0; 0,cos(gs),-sin(gs); 0,sin(gs),cos(gs)];
+rot_om  = [cos(omega),-sin(omega),0; sin(omega),cos(omega),0; 0,0,1];
+corr = (rot_om * (rot_dpsi*rot_gl*rot_gs) * rot_om')';
+
+% Matrix to convert from spectrometer coords to orthormal frame defined by notional directions of u, v
+cryst = [cos(psi),sin(psi),0; -sin(psi),cos(psi),0; 0,0,1];
+
+% Combine to get matrix to convert from spectrometer coordinates to crystal Cartesian coordinates
+spec_to_cc = u_matrix\corr*cryst;
+
+% Matrix to convert from crystal Cartesian coords to r.l.u.
+u_to_rlu = inv(b_matrix);
+
+% Matrix to convert from spectrometer coordinates to r.l.u.
+spec_to_rlu = b_matrix\spec_to_cc;
+

--- a/herbert_core/utilities/scientific/ubmatrix.m
+++ b/herbert_core/utilities/scientific/ubmatrix.m
@@ -34,7 +34,6 @@ function [ub, mess, umat] = ubmatrix (u, v, b)
 
 % Original author: T.G.Perring
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 %
 % Horace v0.1   J. van Duijn, T.G.Perring
 


### PR DESCRIPTION
This small PR is the part of changes, related to urange clarification. Here I have added run_id to rundata class as apparently this number may be necessary in some gen_sqw scenarios. 