### PR TITLE
276 add skip

### DIFF
--- a/_test/shared/matlab_xunit/xunit/TestCase.m
+++ b/_test/shared/matlab_xunit/xunit/TestCase.m
@@ -25,26 +25,32 @@
 %   See also TestComponent, TestSuite
 
 %   Steven L. Eddins
+%   Modified J. Wilkins 19-01-2021
 %   Copyright 2008-2010 The MathWorks, Inc.
 
 classdef TestCase < TestComponent
-    
+
     properties
         MethodName
     end
-    
-    
+
+    properties(Constant)
+        passed = 1
+        skipped = 2
+        failed = 0
+    end
+
     methods
         function self = TestCase(testMethod)
             %TestCase Constructor
             %   TestCase(methodName) constructs a TestCase object using the
             %   specified testMethod (a string).
-            
+
             self.MethodName = testMethod;
             self.Name = testMethod;
             self.Location = which(class(self));
         end
-        
+
         function [did_pass,num_tests_run] = run(self, monitor,num_tests_run)
             %run Execute the test case
             %    test_case.run(monitor) calls the TestCase object's setUp()
@@ -58,17 +64,17 @@ classdef TestCase < TestComponent
             %    test_case.run() automatically uses a
             %    CommandWindowTestRunDisplay object in order to print test
             %    suite execution information to the Command Window.
-            
+
             if nargin < 2
                 monitor = CommandWindowTestRunDisplay();
             end
             if nargin< 3
                 num_tests_run = 0;
             end
-            
-            did_pass = true;
+
+            did_pass = self.passed;
             monitor.testComponentStarted(self);
-            
+
             try
                 self.setUp();
                 if ischar(self.MethodName)
@@ -87,13 +93,18 @@ classdef TestCase < TestComponent
                     fprintf('************  starting test: %s\n',name2print);
                     fprintf('**************************************************** \n');
                 end
-                
+
                 try
                     % Call the test method.
                     f(self);
                 catch failureException
-                    monitor.testCaseFailure(self, failureException);
-                    did_pass = false;
+                    if (strcmp(failureException.identifier,'testSkipped'))
+                        monitor.testCaseSkip(self, skipException)
+                        did_pass = self.skipped;
+                    else
+                        monitor.testCaseFailure(self, failureException);
+                        did_pass = self.failed;
+                    end
                 end
                 if self.print_running_tests
                     tEnd = toc(tStart);
@@ -102,30 +113,30 @@ classdef TestCase < TestComponent
                         name2print,tEnd);
                     fprintf('**************************************************** \n');
                 end
-                
-                
+
+
                 self.tearDown();
-                
+
             catch errorException
                 monitor.testCaseError(self, errorException);
-                did_pass = false;
+                did_pass = self.failed;
             end
-            
+
             monitor.testComponentFinished(self, did_pass);
             num_tests_run = num_tests_run+1;
         end
-        
+
         function num = numTestCases(self)
             num = 1;
         end
-        
+
         function print(self, numLeadingBlanks)
             if nargin < 2
                 numLeadingBlanks = 0;
             end
             fprintf('%s%s\n', blanks(numLeadingBlanks), self.Name);
         end
-        
+
     end
-    
+
 end

--- a/_test/shared/matlab_xunit/xunit/TestCase.m
+++ b/_test/shared/matlab_xunit/xunit/TestCase.m
@@ -98,8 +98,8 @@ classdef TestCase < TestComponent
                     % Call the test method.
                     f(self);
                 catch failureException
-                    if (strcmp(failureException.identifier,'testSkipped'))
-                        monitor.testCaseSkip(self, skipException)
+                    if (strcmp(failureException.identifier,'testSkipped:testSkipped'))
+                        monitor.testCaseSkip(self, failureException);
                         did_pass = self.skipped;
                     else
                         monitor.testCaseFailure(self, failureException);

--- a/_test/shared/matlab_xunit/xunit/TestCase.m
+++ b/_test/shared/matlab_xunit/xunit/TestCase.m
@@ -34,12 +34,6 @@ classdef TestCase < TestComponent
         MethodName
     end
 
-    properties(Constant)
-        passed = 1
-        skipped = 2
-        failed = 0
-    end
-
     methods
         function self = TestCase(testMethod)
             %TestCase Constructor

--- a/_test/shared/matlab_xunit/xunit/TestComponent.m
+++ b/_test/shared/matlab_xunit/xunit/TestComponent.m
@@ -13,37 +13,44 @@ classdef TestComponent < handle
     %       Location - Directory where test component is defined
     %
     %   See TestCase, TestSuite
-    
+
     %   Steven L. Eddins
+    %   Modified J. Wilkins 19-01-2021
     %   Copyright 2008-2009 The MathWorks, Inc.
-    
+
     properties
         Name = '';
         Location = '';
         % If true, prings the names of rest cases beeing run in addition to
-        % normal test output. Usftul for debugging test folders, failing on
+        % normal test output. Useful for debugging test folders, failing on
         % time-out. Default  - false;
         print_running_tests = false;
     end
-    
+
+    properties(Constant)
+        passed = 1
+        skipped = 2
+        failed = 0
+    end
+
     properties (Access = 'protected')
         PrintIndentationSize = 4
     end
-    
+
     methods (Abstract)
         print()
         %print Display summary of test component to Command Window
         %   obj.print() displays information about the test component to the
         %   Command Window.
-        
+
         run()
         %run Execute test cases
         %   obj.run() executes all the test cases in the test component
-        
+
         numTestCases()
         %numTestCases Number of test cases in test component
     end
-    
+
     methods
         function setUp(self)
             %setUp Set up test fixture
@@ -51,7 +58,7 @@ classdef TestComponent < handle
             %   method.  Test writers can override setUp if necessary to
             %   initialize a test fixture.
         end
-        
+
         function tearDown(self)
             %tearDown Tear down test fixture
             %   test_component.tearDown() is at the end of the method.  Test
@@ -70,7 +77,7 @@ classdef TestComponent < handle
                 name = cont{end};
             end
         end
-        
-        
+
+
     end
 end

--- a/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
+++ b/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
@@ -18,40 +18,42 @@ classdef TestRunDisplay < TestRunMonitor
 %   See also TestRunLogger, TestRunMonitor, TestSuite
 
 %   Steven L. Eddins
+%   Modified J. Wilkins 19-01-2021
+
 %   Copyright 2008-2010 The MathWorks, Inc.
-    
+
     properties (SetAccess = private)
         %TestCaseCount - Number of test cases executed
         TestCaseCount
-        
+
         %Faults - Struct array of test fault info
         %   Faults is a struct array with these fields:
         %       Type      - either 'failure' or 'error'
         %       TestCase  - the TestCase object that suffered the fault
         %       Exception - the MException thrown when the fault occurred
         Faults = struct('Type', {}, 'TestCase', {}, 'Exception', {});
-        
+
     end
-    
+
     properties (SetAccess = private, GetAccess = private)
         %InitialTic - Out of tic at beginning of test run
         InitialTic
-        
+
         %InitialComponent First test component executed
         %   InitialComponent is set to the first test component executed in the
         %   test run.  This component is saved so that the end of the test run
         %   can be identified.
-        InitialComponent = []   
-        
+        InitialComponent = []
+
     end
-    
+
     properties (Access = protected)
         %FileHandle - Handle used by fprintf for displaying results.
         %             Default value of 1 displays to Command Window.
         FileHandle = 1
     end
-        
-    
+
+
     methods
         function self = TestRunDisplay(output)
             if nargin > 0
@@ -67,32 +69,34 @@ classdef TestRunDisplay < TestRunMonitor
                 end
             end
         end
-        
+
         function testComponentStarted(self, component)
             %testComponentStarted Update Command Window display
-            %    If the InitialComponent property is not yet set, 
+            %    If the InitialComponent property is not yet set,
             %    obj.testComponentStarted(component) sets the property and calls
             %    obj.testRunStarted(component).
-            
+
             if isempty(self.InitialComponent)
                 self.InitialComponent = component;
                 self.testRunStarted(component);
             end
-        end    
-            
+        end
+
         function testComponentFinished(self, component, did_pass)
             %testComponentFinished Update Command Window display
-            %    If component is a TestCase object, then 
+            %    If component is a TestCase object, then
             %    obj.testComponentFinished(component, did_pass) prints pass/fail
             %    information to the Command Window.
             %
             %    If component is the InitialComponent, then
             %    obj.testRunFinished(did_pass) is called.
-            
+
             if isa(component, 'TestCase')
                 self.TestCaseCount = self.TestCaseCount + 1;
-                if did_pass
+                if did_pass == 1
                     fprintf(self.FileHandle, '.');
+                elseif did_pass == 2
+                    fprintf(self.FileHandle, 'S');
                 else
                     fprintf(self.FileHandle, 'F');
                 end
@@ -101,38 +105,46 @@ classdef TestRunDisplay < TestRunMonitor
                     fprintf(self.FileHandle, '\n');
                 end
             end
-            
+
             if isequal(component, self.InitialComponent)
                 self.testRunFinished(did_pass);
             end
         end
-               
+
         function testCaseFailure(self, test_case, failure_exception)
             %testCaseFailure Log test failure information
             %    obj.testCaseFailure(test_case, failure_exception) logs the test
             %    case failure information.
-            
+
             self.logFault('failure', test_case, ...
                 failure_exception);
         end
-        
+
         function testCaseError(self, test_case, error_exception)
             %testCaseError Log test error information
             %    obj.testCaseError(test_case, error_exception) logs the test
             %    case error information.
-            
+
             self.logFault('error', test_case, ...
                 error_exception);
         end
-        
+
+        function testCaseSkip(self, test_case, skip_exception)
+            %testCaseSkip Log test skip information
+            %    obj.testCaseSkip(test_case, skip_exception) logs the test
+            %    case skip information.
+
+            self.logFault('skip', test_case, ...
+                skip_exception);
+        end
     end
-    
+
     methods (Access = protected)
         function testRunStarted(self, component)
             %testRunStarted Update Command Window display
             %    obj.testRunStarted(component) displays information about the test
             %    run to the Command Window.
-            
+
             self.InitialTic = tic;
             self.TestCaseCount = 0;
             num_cases = component.numTestCases();
@@ -144,36 +156,36 @@ classdef TestRunDisplay < TestRunMonitor
             fprintf(self.FileHandle, 'Starting test run with %d test %s.\n', ...
                 num_cases, str);
         end
-        
+
         function testRunFinished(self, did_pass)
             %testRunFinished Update Command Window display
             %    obj.testRunFinished(component) displays information about the test
             %    run results, including any test failures, to the Command Window.
-            
+
             if did_pass
                 result = 'PASSED';
             else
                 result = 'FAILED';
             end
-            
+
             fprintf(self.FileHandle, '\n%s in %.3f seconds.\n', result, toc(self.InitialTic));
-            
+
             self.displayFaults();
         end
-        
 
-        
+
+
         function logFault(self, type, test_case, exception)
             %logFault Log test fault information
             %    obj.logFault(type, test_case, exception) logs test fault
             %    information. type is either 'failure' or 'error'. test_case is a
             %    TestCase object.  exception is an MException object.
-            
+
             self.Faults(end + 1).Type = type;
             self.Faults(end).TestCase = test_case;
             self.Faults(end).Exception = exception;
         end
-        
+
         function displayFaults(self)
             %displayFaults Display test fault info to Command Window
             %    obj.displayFaults() displays a summary of each test failure and
@@ -194,15 +206,15 @@ classdef TestRunDisplay < TestRunMonitor
                 fprintf(self.FileHandle, '\n');
             end
         end
-        
+
     end
-    
+
 end
 
 function displayStack(stack, file_handle)
 %displayStack Display stack trace from MException instance
 %   displayStack(stack) prints information about an exception stack to the
-%   command window. 
+%   command window.
 
 for k = 1:numel(stack)
     filename = stack(k).file;
@@ -227,7 +239,7 @@ function new_stack = filterStack(stack)
 % the user-written code under test.  These calls are useful to see.
 %
 % 3. The final set of function calls are methods in the various framework
-% classes.  There are usually several of these calls, which clutter up the 
+% classes.  There are usually several of these calls, which clutter up the
 % stack display without being that useful.
 %
 % The pattern above suggests the following stack filtering strategy: Once the
@@ -253,6 +265,5 @@ for k = 1:numel(stack)
 end
 
 new_stack = stack(1:last_keeper);
-            
-end
 
+end

--- a/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
+++ b/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
@@ -33,6 +33,7 @@ classdef TestRunDisplay < TestRunMonitor
         %       Exception - the MException thrown when the fault occurred
         Faults = struct('Type', {}, 'TestCase', {}, 'Exception', {});
 
+        NumSkips = 0;
     end
 
     properties (SetAccess = private, GetAccess = private)
@@ -44,7 +45,6 @@ classdef TestRunDisplay < TestRunMonitor
         %   test run.  This component is saved so that the end of the test run
         %   can be identified.
         InitialComponent = []
-
     end
 
     properties (Access = protected)
@@ -93,11 +93,12 @@ classdef TestRunDisplay < TestRunMonitor
 
             if isa(component, 'TestCase')
                 self.TestCaseCount = self.TestCaseCount + 1;
-                if did_pass == 1
+                switch did_pass
+                  case component.passed
                     fprintf(self.FileHandle, '.');
-                elseif did_pass == 2
+                  case component.skipped
                     fprintf(self.FileHandle, 'S');
-                else
+                  case component.failed
                     fprintf(self.FileHandle, 'F');
                 end
                 line_length = 20;
@@ -135,7 +136,8 @@ classdef TestRunDisplay < TestRunMonitor
             %    case skip information.
 
             self.logFault('skip', test_case, ...
-                skip_exception);
+                          skip_exception);
+            self.NumSkips = self.NumSkips + 1;
         end
     end
 
@@ -168,7 +170,7 @@ classdef TestRunDisplay < TestRunMonitor
                 result = 'FAILED';
             end
 
-            fprintf(self.FileHandle, '\n%s in %.3f seconds.\n', result, toc(self.InitialTic));
+            fprintf(self.FileHandle, '\n%s in %.3f seconds, %d tests skipped.\n', result, toc(self.InitialTic), self.NumSkips);
 
             self.displayFaults();
         end

--- a/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
+++ b/_test/shared/matlab_xunit/xunit/TestRunDisplay.m
@@ -194,6 +194,12 @@ classdef TestRunDisplay < TestRunMonitor
                 faultData = self.Faults(k);
                 if strcmp(faultData.Type, 'failure')
                     str = 'Failure';
+                elseif strcmp(faultData.Type, 'skip')
+                    % Only print if verbose
+                    if ~isa(self, 'VerboseTestRunDisplay')
+                        continue
+                    end
+                    str = 'Skipped';
                 else
                     str = 'Error';
                 end

--- a/_test/shared/matlab_xunit/xunit/TestRunLogger.m
+++ b/_test/shared/matlab_xunit/xunit/TestRunLogger.m
@@ -1,5 +1,5 @@
 %TestRunLogger Collect data (silently) from running test suite
-%   TestRunLogger is a subclass of TestRunMonitor uses to collect information 
+%   TestRunLogger is a subclass of TestRunMonitor uses to collect information
 %   from an executing test component (either a test case or a test suite).
 %   It maintains a record of event notifications received, as well as any test
 %   failures or test errors.
@@ -20,26 +20,31 @@
 %   See also CommandWindowTestRunDisplay, TestRunMonitor, TestSuite
 
 %   Steven L. Eddins
+%   Modified J. Wilkins 19-01-2021
 %   Copyright 2008-2009 The MathWorks, Inc.
 
 classdef TestRunLogger < TestRunMonitor
 
-    properties (SetAccess = protected)  
+    properties (SetAccess = protected)
         %Log Cell array of test notification strings
         %   Test notification strings include 'TestRunStarted',
         %   'TestRunFinished', 'TestComponentStarted', 'TestComponentFinished',
         %   'TestCaseFailure', and 'TestCaseError'.
         Log
-        
+
         %NumFailures Number of test failures during execution
         NumFailures = 0
-        
+
         %NumErrors Number of test errors during execution
         NumErrors = 0
-        
+
+        %NumSkippedTests
+        NumSkips = 0
+
         %NumTestCases Total number of test cases executed
         NumTestCases = 0
-        
+
+
         %Faults Struct array of test fault information
         %   Faults is a struct array with the fields Type, TestCase, and
         %   Exception.  Type is either 'failure' or 'error'.  TestCase is the
@@ -47,54 +52,61 @@ classdef TestRunLogger < TestRunMonitor
         %   MException object thrown during the fault.
         Faults = struct('Type', {}, 'TestCase', {}, 'Exception', {});
     end
-    
+
     properties (SetAccess = private, GetAccess = private)
         InitialTestComponent = []
     end
 
     methods
-        
+
         function testComponentStarted(self, component)
             if isempty(self.InitialTestComponent)
                 self.InitialTestComponent = component;
                 self.appendToLog('TestRunStarted');
             end
-            
+
             self.appendToLog('TestComponentStarted');
-            
+
             if isa(component, 'TestCase')
                 self.NumTestCases = self.NumTestCases + 1;
             end
         end
-            
+
         function testComponentFinished(self, component, did_pass)
             self.appendToLog('TestComponentFinished');
-            
+
             if isequal(component, self.InitialTestComponent)
                 self.appendToLog('TestRunFinished');
             end
         end
-        
+
         function testCaseFailure(self, test_case, failure_exception)
             self.appendToLog('TestCaseFailure');
             self.NumFailures = self.NumFailures + 1;
             self.logFault('failure', test_case, ...
                 failure_exception);
         end
-        
+
         function testCaseError(self, test_case, error_exception)
             self.appendToLog('TestCaseError');
             self.NumErrors = self.NumErrors + 1;
             self.logFault('error', test_case, ...
                 error_exception);
         end
+
+        function testCaseSkip(self, test_case, skip_exception)
+            self.appendToLog('TestCaseSkip');
+            self.NumSkips = self.NumSkips + 1;
+            self.logFault('skip', test_case, ...
+                skip_exception);
+        end
     end
-    
+
     methods (Access = private)
         function appendToLog(self, item)
             self.Log{end+1} = item;
         end
-        
+
         function logFault(self, type, test_case, exception)
             self.Faults(end + 1).Type = type;
             self.Faults(end).TestCase = test_case;

--- a/_test/shared/matlab_xunit/xunit/TestRunMonitor.m
+++ b/_test/shared/matlab_xunit/xunit/TestRunMonitor.m
@@ -13,23 +13,27 @@
 %       testComponentFinished - Called when test component run finished
 %       testCaseFailure       -   Called when a test case fails
 %       testCaseError         - Called when a test case causes an error
+%       testCaseSkip          - Called when a test case is skipped
 %
 %   See also CommandWindowTestRunDisplay, TestRunLogger, TestCase, TestSuite
 
 %   Steven L. Eddins
+%   Modified J. Wilkins 19-01-2021
+
 %   Copyright 2008-2009 The MathWorks, Inc.
 
 classdef TestRunMonitor < handle
 
     methods (Abstract)
-        
+
         testComponentStarted(self, component)
-            
+
         testComponentFinished(self, component, did_pass)
-        
+
         testCaseFailure(self, test_case, failure_exception)
-        
+
         testCaseError(self, test_case, error_exception)
-        
+
+        testCaseSkip(self, test_case, skip_exception)
     end
 end

--- a/_test/shared/matlab_xunit/xunit/TestSuite.m
+++ b/_test/shared/matlab_xunit/xunit/TestSuite.m
@@ -45,66 +45,68 @@
 %   See also CommandWindowTestRunDisplay, TestCase, TestComponent, TestRunLogger
 
 %   Steven L. Eddins
+%   Modified J. Wilkins 19-01-2021
 %   Copyright 2008-2010 The MathWorks, Inc.
 
 classdef TestSuite < TestComponent
-    
+
     properties (SetAccess = protected)
         TestCaseClasses = containers.Map();
         TestComponents  = {};
         PrintRunInfo    = containers.Map('KeyType','char','ValueType','logical');
     end
-    
+
     methods
-        
+
         function self = TestSuite(name)
             %TestSuite Constructor
             %   suite = TestSuite constructs an empty test suite. suite =
             %   TestSuite(name) constructs a test suite by searching for test
             %   cases defined in an M-file with the specified name.
-            
+
             if nargin >= 1
                 self = TestSuite.fromName(name);
             end
             self.TestCaseClasses  = containers.Map();
         end
-        
-        
+
+
         function [did_pass_out,num_tests_run] = run(self, monitor,num_tests_run)
             %run Execute test cases in test suite
             %   did_pass = suite.run() executes all test cases in the test
             %   suite, returning a logical value indicating whether or not all
             %   test cases passed.
-            
+
             if nargin < 2
                 monitor = CommandWindowTestRunDisplay();
             end
             if nargin<3
                 num_tests_run = 0;
             end
-            
+
             monitor.testComponentStarted(self);
             did_pass = true;
-            
+
             self.setUp();
-            
+
             for k = 1:numel(self.TestComponents)
                 [this_component_passed,num_tests_run] = self.TestComponents{k}.run(monitor,num_tests_run);
-                did_pass = did_pass && this_component_passed;
+                % Logical cast not "necessary" as auto-cast, but for clarity
+                did_pass = logical(did_pass) && this_component_passed;
             end
-            
+
             self.tearDown();
-            
+
             monitor.testComponentFinished(self, did_pass);
-            
+
             if nargout > 0
                 did_pass_out = did_pass;
             end
         end
-        
+
         function num = numTestCases(self)
             %numTestCases Number of test cases in test suite
-            
+
             num = 0;
             for k = 1:numel(self.TestComponents)
                 component_k = self.TestComponents{k};
@@ -115,12 +117,12 @@ classdef TestSuite < TestComponent
                 end
             end
         end
-        
+
         function print(self, numLeadingBlanks)
             %print Display test suite summary to Command Window
             %   test_suite.print() displays a summary of the test suite to the
             %   Command Window.
-            
+
             if nargin < 2
                 numLeadingBlanks = 0;
             end
@@ -130,24 +132,24 @@ classdef TestSuite < TestComponent
                     self.PrintIndentationSize);
             end
         end
-        
+
         function add(self, component)
             %add Add test component to test suite
             %   test_suite.add(component) adds the TestComponent object to the
             %   test suite.
-            
+
             if iscell(component)
                 self.TestComponents((1:numel(component)) + end) = component;
             else
                 self.TestComponents{end + 1} = component;
             end
         end
-        
+
         function keepMatchingTestCase(self, name)
             %keepMatchingTestCase Keep only the named test component
             %   test_suite.keepMatchingTestCase(name) keeps only the test
             %   component with a matching name and discards the rest.
-            
+
             idx = [];
             for k = 1:numel(self.TestComponents)
                 if strcmp(self.TestComponents{k}.Name, name)
@@ -173,7 +175,7 @@ classdef TestSuite < TestComponent
                 self.TestComponents = self.TestComponents(idx);
             end
         end
-        
+
         function delete(self)
             if ~self.TestCaseClasses.isempty()
                 keys = self.TestCaseClasses.keys();
@@ -187,32 +189,32 @@ classdef TestSuite < TestComponent
             self.TestCaseClasses = containers.Map();
         end
     end
-    
+
     methods (Static)
         function suite = fromTestCaseClassName(class_name)
             %fromTestCaseClassName Construct test suite from TestCase class name
             %   suite = TestSuite.fromTestCaseClassName(name) constructs a
             %   TestSuite object from the name of a TestCase subclass.
-            
+
             if ~xunit.utils.isTestCaseSubclass(class_name)
                 error('xunit:fromTestCaseClassName', ...
                     'Input string "%s" is not the name of a TestCase class.', ...
                     class_name);
             end
-            
+
             suite = TestSuite;
             suite.Name = class_name;
             suite.Location = which(class_name);
             cli = feval(class_name,class_name);
             suite.TestCaseClasses(class_name) = cli;
             print_addinfo = cli.print_running_tests;
-            
+
             methods = getClassMethods(class_name);
             for k = 1:numel(methods)
                 if methodIsConstructor(methods{k})
                     continue
                 end
-                
+
                 method_name = methods{k}.Name;
                 if xunit.utils.isTestString(method_name)
                     tc_str = sprintf('@(x)%s(x)',method_name);
@@ -225,9 +227,9 @@ classdef TestSuite < TestComponent
                     suite.add(tc);
                 end
             end
-            
+
         end
-        
+
         function suite = fromName(name,folder)
             %fromName Construct test suite from M-file name
             %   test_suite = TestSuite.fromName(name) constructs a TestSuite
@@ -240,51 +242,51 @@ classdef TestSuite < TestComponent
             %   particular named test case.  For example, TestSuite.fromName('MyTests:testA')
             %   constructs a TestSuite object containing only the test case
             %   named 'testA' found in the TestCase subclass MyTests.
-            
+
             if isdir(name)
                 suite = TestSuiteInDir(name);
                 suite.gatherTestCases();
                 return;
             end
             if nargin>1
-                suite = TestSuiteInDir(folder);                
+                suite = TestSuiteInDir(folder);
                 suite.add(TestSuite.fromName(name));
                 return;
             end
-            
+
             [name, filter_string] = strtok(name, ':');
             if ~isempty(filter_string)
                 filter_string = strrep(filter_string,':','');
             end
-            
+
             if xunit.utils.isTestCaseSubclass(name)
                 suite = TestSuite.fromTestCaseClassName(name);
-                
+
             elseif ~isempty(meta.class.fromName(name))
                 % Input is the name of a class that is not a TestCase subclass.
                 % Return an empty test suite.
                 suite = TestSuite();
                 suite.Name = name;
-                
+
             elseif isPackage(name)
                 suite = TestSuite.fromPackageName(name);
-                
+
             else
-                
+
                 try
                     if nargout(name) == 0
                         suite = TestSuite();
                         suite.Name = name;
                         suite.add(FunctionHandleTestCase(str2func(name), [], []));
                         suite.Location = which(name);
-                        
+
                     else
                         suite = feval(name);
                         if ~isa(suite, 'TestSuite')
                             error('Function did not return a TestSuite object.');
                         end
                     end
-                    
+
                 catch
                     % Ordinary function does not appear to contain tests.
                     % Return an empty test suite.
@@ -292,12 +294,12 @@ classdef TestSuite < TestComponent
                     suite.Name = name;
                 end
             end
-            
+
             if ~isempty(filter_string)
                 suite.keepMatchingTestCase(filter_string);
             end
         end
-        
+
         function test_suite = fromPwd()
             %fromPwd Construct test suite from present directory
             %   test_suite = TestSuite.fromPwd() constructs a TestSuite object
@@ -305,11 +307,11 @@ classdef TestSuite < TestComponent
             %   all TestCase subclasses will be found, as well as simple and
             %   subfunction-based M-file tests beginning with the string 'test'
             %   or 'Test'.
-            
+
             test_suite = TestSuite();
             test_suite.Name = pwd;
             test_suite.Location = pwd;
-            
+
             mfiles = dir(fullfile('.', '*.m'));
             for k = 1:numel(mfiles)
                 [~, name] = fileparts(mfiles(k).name);
@@ -323,13 +325,13 @@ classdef TestSuite < TestComponent
                 end
             end
         end
-        
+
         function test_suite = fromPackageName(name)
             %fromPackageName Construct test suite from package name
             %   test_suite = TestSuite.fromPackageName(name) constructs a
             %   TestSuite object from all the test components found in the
             %   specified package.
-            
+
             package_info = meta.package.fromName(name);
             if isempty(package_info)
                 error('xunit:fromPackageName:invalidName', ...
@@ -339,7 +341,7 @@ classdef TestSuite < TestComponent
             test_suite = TestSuite();
             test_suite.Name = name;
             test_suite.Location = 'Package';
-            
+
             for k = 1:numel(package_info.Packages)
                 pkg_name = package_info.Packages{k}.Name;
                 pkg_suite = TestSuite.fromPackageName(pkg_name);
@@ -347,7 +349,7 @@ classdef TestSuite < TestComponent
                     test_suite.add(TestSuite.fromPackageName(pkg_name));
                 end
             end
-            
+
             class_names = cell(1, numel(package_info.Classes));
             for k = 1:numel(package_info.Classes)
                 class_name = package_info.Classes{k}.Name;
@@ -356,7 +358,7 @@ classdef TestSuite < TestComponent
                     test_suite.add(TestSuite.fromTestCaseClassName(class_name));
                 end
             end
-            
+
             for k = 1:numel(package_info.Functions)
                 function_name = package_info.Functions{k}.Name;
                 if xunit.utils.isTestString(function_name)

--- a/_test/shared/matlab_xunit/xunit/TestSuite.m
+++ b/_test/shared/matlab_xunit/xunit/TestSuite.m
@@ -91,8 +91,7 @@ classdef TestSuite < TestComponent
 
             for k = 1:numel(self.TestComponents)
                 [this_component_passed,num_tests_run] = self.TestComponents{k}.run(monitor,num_tests_run);
-                % Logical cast not "necessary" as auto-cast, but for clarity
-                did_pass = logical(did_pass) && this_component_passed;
+                did_pass = did_pass && (this_component_passed ~= self.failed);
             end
 
             self.tearDown();

--- a/_test/shared/matlab_xunit/xunit/VerboseTestRunDisplay.m
+++ b/_test/shared/matlab_xunit/xunit/VerboseTestRunDisplay.m
@@ -55,15 +55,18 @@ classdef VerboseTestRunDisplay < TestRunDisplay
 
             component_run_time = toc(self.popTic());
 
-            if did_pass == 1
-                fprintf(self.FileHandle, 'passed in %12.6f seconds\n', component_run_time);
-            elseif did_pass == 2
-                fprintf(self.FileHandle, 'test skipped\n');
-            else
-                fprintf(self.FileHandle, 'FAILED in %12.6f seconds\n', component_run_time);
+            switch did_pass
+              case component.passed
+                fprintf(self.FileHandle, 'passed in %12.6f seconds', component_run_time);
+              case component.skipped
+                fprintf(self.FileHandle, 'test skipped');
+              case component.failed
+                fprintf(self.FileHandle, 'FAILED in %12.6f seconds', component_run_time);
             end
 
             if ~isa(component, 'TestCase')
+                fprintf(self.FileHandle, ', %d tests skipped.\n\n', self.NumSkips);
+            else
                 fprintf(self.FileHandle, '\n');
             end
 

--- a/_test/shared/matlab_xunit/xunit/VerboseTestRunDisplay.m
+++ b/_test/shared/matlab_xunit/xunit/VerboseTestRunDisplay.m
@@ -11,39 +11,40 @@ classdef VerboseTestRunDisplay < TestRunDisplay
 %   See also TestRunDisplay, TestRunLogger, TestRunMonitor, TestSuite
 
 %   Steven L. Eddins
-%   Copyright 2010 The MathWorks, Inc.     
-    
+%   Modified J. Wilkins 19-01-2021
+%   Copyright 2010 The MathWorks, Inc.
+
     properties (SetAccess = private, GetAccess = private)
         TicStack = uint64([])
     end
-    
+
     methods
         function self = VerboseTestRunDisplay(output)
             if nargin < 1
                 output = 1;
             end
-            
+
             self = self@TestRunDisplay(output);
         end
-        
+
         function testComponentStarted(self, component)
             %testComponentStarted Update Command Window display
-            
+
             self.pushTic();
-            
+
             if ~isa(component, 'TestCase')
                 fprintf(self.FileHandle, '\n');
             end
-            
+
             fprintf(self.FileHandle, '%s%s', self.indentationSpaces(), component.Name);
-            
+
             if ~isa(component, 'TestCase')
                 fprintf(self.FileHandle, '\n');
             else
                 fprintf(self.FileHandle, ' %s ', self.leaderDots(component.Name));
             end
-        end    
-            
+        end
+
         function testComponentFinished(self, component, did_pass)
             %testComponentFinished Update Command Window display
 
@@ -51,62 +52,64 @@ classdef VerboseTestRunDisplay < TestRunDisplay
                 fprintf(self.FileHandle, '%s%s %s ', self.indentationSpaces(), component.Name, ...
                     self.leaderDots(component.Name));
             end
-            
+
             component_run_time = toc(self.popTic());
-            
-            if did_pass
+
+            if did_pass == 1
                 fprintf(self.FileHandle, 'passed in %12.6f seconds\n', component_run_time);
+            elseif did_pass == 2
+                fprintf(self.FileHandle, 'test skipped\n');
             else
                 fprintf(self.FileHandle, 'FAILED in %12.6f seconds\n', component_run_time);
             end
-            
+
             if ~isa(component, 'TestCase')
                 fprintf(self.FileHandle, '\n');
             end
-            
+
             if isempty(self.TicStack)
                 self.testRunFinished();
             end
-                
+
         end
-        
+
     end
-    
+
     methods (Access = protected)
         function testRunFinished(self)
             %testRunFinished Update Command Window display
             %    obj.testRunFinished(component) displays information about the test
             %    run results, including any test failures, to the Command
             %    Window.
-            
+
             self.displayFaults();
         end
     end
-    
+
     methods (Access = private)
         function pushTic(self)
             self.TicStack(end+1) = tic;
         end
-        
+
         function t1 = popTic(self)
             t1 = self.TicStack(end);
             self.TicStack(end) = [];
         end
-        
+
         function str = indentationSpaces(self)
             str = repmat(' ', 1, self.numIndentationSpaces());
         end
-        
+
         function n = numIndentationSpaces(self)
             indent_level = numel(self.TicStack) - 1;
             n = 3 * indent_level;
         end
-        
+
         function str = leaderDots(self, name)
             num_dots = max(0, 60 - self.numIndentationSpaces() - numel(name));
             str = repmat('.', 1, num_dots);
         end
-        
+
     end
-    
+
 end

--- a/_test/shared/matlab_xunit/xunit/skipTest.m
+++ b/_test/shared/matlab_xunit/xunit/skipTest.m
@@ -1,0 +1,14 @@
+function skipTest(reason)
+%skipTest skips a test providing a reason for the skip for logs
+
+%   J. Wilkins
+
+if nargin < 1
+    message = 'Test skipped.';
+else
+    message = reason;
+end
+
+throwAsCaller(MException('testSkipped:testSkipped', '%s', message));
+
+end

--- a/_test/test_utilities/test_skip.m
+++ b/_test/test_utilities/test_skip.m
@@ -1,0 +1,24 @@
+classdef test_skip < TestCase
+    properties
+    end
+    methods
+        function this=test_skip(varargin)
+            if nargin>0
+                name = varargin{1};
+            else
+                name  = 'test_skip';
+            end
+            this = this@TestCase(name);
+
+        end
+
+        %------------------------------------------------------------------
+        function test_skip_with_message(this)
+            skipTest('This test is skipped because of custom reasons.');
+        end
+
+        function test_skip_without_message(this)
+            skipTest();
+        end
+    end
+end

--- a/_test/test_utilities/test_skip.m
+++ b/_test/test_utilities/test_skip.m
@@ -12,7 +12,7 @@ classdef test_skip < TestCase
 
         %------------------------------------------------------------------
         function test_skip_with_message(this)
-            skipTest('This test is skipped because of custom reasons.');
+            skipTest('This is a custom message to test reason reporting.');
         end
 
         function test_skip_without_message(this)

--- a/_test/test_utilities/test_skip.m
+++ b/_test/test_utilities/test_skip.m
@@ -1,6 +1,4 @@
 classdef test_skip < TestCase
-    properties
-    end
     methods
         function this=test_skip(varargin)
             if nargin>0


### PR DESCRIPTION
Add skipped tests via the skipTest function into the test suite

E.g.

```MATLAB
skipTest('I don''t like this test')
```

This will print an `S` rather than `F`, count as passed and will display detailed reasoning on `runtests -verbose` but not on standard runs. 