### PR TITLE
Masking disabled on keys

### DIFF
--- a/_test/test_data_loaders/test_rundata_rm_masked.m
+++ b/_test/test_data_loaders/test_rundata_rm_masked.m
@@ -34,7 +34,7 @@ classdef test_rundata_rm_masked< TestCase
             assertEqual(run.ERR,err);
             assertEqual(run.det_par,det);
         end
-        function test_works_removesNAN(~)
+        function test_works_removesNaNandInf(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);
@@ -67,7 +67,7 @@ classdef test_rundata_rm_masked< TestCase
             assertEqual(numel(det.width),5);
         end
         
-        function test_inf_masking_disabled(~)
+        function test_Inf_masking_disabled(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);
@@ -84,7 +84,7 @@ classdef test_rundata_rm_masked< TestCase
             assertEqual(numel(det.width),4);
         end
         
-        function test_nan_masking_disabled(~)
+        function test_NaN_masking_disabled(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);

--- a/_test/test_data_loaders/test_rundata_rm_masked.m
+++ b/_test/test_data_loaders/test_rundata_rm_masked.m
@@ -1,6 +1,5 @@
 classdef test_rundata_rm_masked< TestCase
     %
-    % $Revision:: 833 ($Date:: 2019-10-24 20:46:09 +0100 (Thu, 24 Oct 2019) $)
     %
     
     properties
@@ -11,11 +10,11 @@ classdef test_rundata_rm_masked< TestCase
             this = this@TestCase(name);
         end
         % tests themself
-        function test_throws_on_empty_rundata(this)
+        function test_throws_on_empty_rundata(~)
             f = @()rm_masked(rundata());
             assertExceptionThrown(f,'RUNDATA:rm_masked');
         end
-        function test_throws_on_inconsisten_rundata(this)
+        function test_throws_on_inconsisten_rundata(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);
@@ -23,7 +22,7 @@ classdef test_rundata_rm_masked< TestCase
             f = @()rm_masked(run);
             assertExceptionThrown(f,'RUNDATA:rm_masked');
         end
-        function test_works_do_nothing(this)
+        function test_works_do_nothing(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);
@@ -35,7 +34,7 @@ classdef test_rundata_rm_masked< TestCase
             assertEqual(run.ERR,err);
             assertEqual(run.det_par,det);
         end
-        function test_works_removesNAN(this)
+        function test_works_removesNAN(~)
             run=rundata();
             run.S=ones(3,5);
             run.ERR=ones(3,5);
@@ -43,13 +42,65 @@ classdef test_rundata_rm_masked< TestCase
             run.det_par=get_hor_format(ones(6,5),'fffff');
             
             run.S(1,1)=NaN;
+            run.S(1,2)=Inf;
             
             [s,err,det]=rm_masked(run);
+            
+            assertEqual(size(s),[3,3]);
+            assertEqual(size(err),size(s));
+            assertEqual(numel(det.width),3);
+        end
+        function test_all_masking_disabled(~)
+            run=rundata();
+            run.S=ones(3,5);
+            run.ERR=ones(3,5);
+            run.en = 1:4;
+            run.det_par=get_hor_format(ones(6,5),'fffff');
+            
+            run.S(1,1)=NaN;
+            run.S(1,2)=Inf;
+            
+            [s,err,det]=rm_masked(run,false,false);
+            
+            assertEqual(size(s),[3,5]);
+            assertEqual(size(err),size(s));
+            assertEqual(numel(det.width),5);
+        end
+        
+        function test_inf_masking_disabled(~)
+            run=rundata();
+            run.S=ones(3,5);
+            run.ERR=ones(3,5);
+            run.en = 1:4;
+            run.det_par=get_hor_format(ones(6,5),'fffff');
+            
+            run.S(1,1)=NaN;
+            run.S(1,2)=Inf;
+            
+            [s,err,det]=rm_masked(run,true,false);
             
             assertEqual(size(s),[3,4]);
             assertEqual(size(err),size(s));
             assertEqual(numel(det.width),4);
         end
+        
+        function test_nan_masking_disabled(~)
+            run=rundata();
+            run.S=ones(3,5);
+            run.ERR=ones(3,5);
+            run.en = 1:4;
+            run.det_par=get_hor_format(ones(6,5),'fffff');
+            
+            run.S(1,1)=NaN;
+            run.S(1,2)=Inf;
+            
+            [s,err,det]=rm_masked(run,false);
+            
+            assertEqual(size(s),[3,4]);
+            assertEqual(size(err),size(s));
+            assertEqual(numel(det.width),4);
+        end
+        
         
     end
 end

--- a/herbert_core/classes/data_loaders/@rundata/rm_masked.m
+++ b/herbert_core/classes/data_loaders/@rundata/rm_masked.m
@@ -1,11 +1,11 @@
-function [S_m,Err_m,det_m]=rm_masked(this,ignore_nan,ignore_inf)
+function [S_m,Err_m,det_m]=rm_masked(obj,ignore_nan,ignore_inf)
 % method removes failed (NaN or Inf) data from the data array and deletes
 % detectors, which provided such signal
 %
-if isempty(this.S)||isempty(this.ERR)||isempty(this.det_par)
+if isempty(obj.S)||isempty(obj.ERR)||isempty(obj.det_par)
     error('RUNDATA:rm_masked',' signal, error and detectors arrays have to be defined\n');
 end
-if any(size(this.S)~=size(this.ERR))||(size(this.S,2)~=numel(this.det_par.x2))
+if any(size(obj.S)~=size(obj.ERR))||(size(obj.S,2)~=numel(obj.det_par.x2))
     error('RUNDATA:rm_masked',' signal error and detectors arrays are not consistent\n');
 end
 if ~exist('ignore_nan','var')
@@ -17,21 +17,21 @@ end
 
 
 if ignore_nan && ignore_inf
-    index_masked = (isnan(this.S)|(isinf(this.S))); % masked pixels
+    index_masked = (isnan(obj.S)|(isinf(obj.S))); % masked pixels
 elseif ignore_nan
-    index_masked = (isnan(this.S));
+    index_masked = (isnan(obj.S));
 elseif ignore_inf
-    index_masked = (isinf(this.S));
+    index_masked = (isinf(obj.S));
 else
-    S_m= this.S;
-    Err_m = this.ERR;
-    det_m = this.det_par;
+    S_m= obj.S;
+    Err_m = obj.ERR;
+    det_m = obj.det_par;
     return
 end
 line_notmasked= ~any(index_masked,1);           % masked detectors (for any energy)
 
 if get(herbert_config,'log_level')> 1
-    [ne,ndet]=size(this.S);
+    [ne,ndet]=size(obj.S);
     nnotmasked = sum(line_notmasked);
     if nnotmasked<ndet
         ndet_mask = ndet-nnotmasked;
@@ -40,9 +40,9 @@ if get(herbert_config,'log_level')> 1
     end
 end
 
-S_m  = this.S(:,line_notmasked);
-Err_m= this.ERR(:,line_notmasked);
-det = this.det_par;
+S_m  = obj.S(:,line_notmasked);
+Err_m= obj.ERR(:,line_notmasked);
+det = obj.det_par;
 det_fields = fields(det);
 det_m = struct();
 for i=1:numel(det_fields)

--- a/herbert_core/classes/data_loaders/@rundata/rm_masked.m
+++ b/herbert_core/classes/data_loaders/@rundata/rm_masked.m
@@ -1,4 +1,4 @@
-function [S_m,Err_m,det_m]=rm_masked(this)
+function [S_m,Err_m,det_m]=rm_masked(this,ignore_nan,ignore_inf)
 % method removes failed (NaN or Inf) data from the data array and deletes
 % detectors, which provided such signal
 %
@@ -8,8 +8,26 @@ end
 if any(size(this.S)~=size(this.ERR))||(size(this.S,2)~=numel(this.det_par.x2))
     error('RUNDATA:rm_masked',' signal error and detectors arrays are not consistent\n');
 end
+if ~exist('ignore_nan','var')
+    ignore_nan = true;
+end
+if ~exist('ignore_inf','var')
+    ignore_inf = true;
+end
 
-index_masked = (isnan(this.S)|(isinf(this.S))); % masked pixels
+
+if ignore_nan && ignore_inf
+    index_masked = (isnan(this.S)|(isinf(this.S))); % masked pixels
+elseif ignore_nan
+    index_masked = (isnan(this.S));
+elseif ignore_inf
+    index_masked = (isinf(this.S));
+else
+    S_m= this.S;
+    Err_m = this.ERR;
+    det_m = this.det_par;
+    return
+end
 line_notmasked= ~any(index_masked,1);           % masked detectors (for any energy)
 
 if get(herbert_config,'log_level')> 1

--- a/herbert_core/classes/data_loaders/@rundata/rm_masked.m
+++ b/herbert_core/classes/data_loaders/@rundata/rm_masked.m
@@ -1,6 +1,14 @@
 function [S_m,Err_m,det_m]=rm_masked(obj,ignore_nan,ignore_inf)
-% method removes failed (NaN or Inf) data from the data array and deletes
+% Method removes failed (NaN or Inf) data from the data array and deletes
 % detectors, which provided such signal
+%
+% Input:
+% obj -- initialized rundata object to check for failied detectors
+% Optional:
+% ignore_nan -- mask detectors with Nan signal. If absent, assumed true
+% ignore_inf -- mask detectors with Inf signal. If absent, assumed true
+%
+% providing both ignore_nan and ignore_inf equal to false, disables masking
 %
 if isempty(obj.S)||isempty(obj.ERR)||isempty(obj.det_par)
     error('RUNDATA:rm_masked',' signal, error and detectors arrays have to be defined\n');
@@ -17,26 +25,28 @@ end
 
 
 if ignore_nan && ignore_inf
-    index_masked = (isnan(obj.S)|(isinf(obj.S))); % masked pixels
+    index_masked = isnan(obj.S)| isinf(obj.S); % masked pixels
 elseif ignore_nan
-    index_masked = (isnan(obj.S));
+    index_masked = isnan(obj.S);
 elseif ignore_inf
-    index_masked = (isinf(obj.S));
+    index_masked = isinf(obj.S);
 else
     S_m= obj.S;
     Err_m = obj.ERR;
     det_m = obj.det_par;
     return
 end
-line_notmasked= ~any(index_masked,1);           % masked detectors (for any energy)
+line_notmasked= ~any(index_masked,1);   % masked detectors (for any energy)
 
 if get(herbert_config,'log_level')> 1
     [ne,ndet]=size(obj.S);
     nnotmasked = sum(line_notmasked);
     if nnotmasked<ndet
         ndet_mask = ndet-nnotmasked;
-        disp(['Masked additional ',num2str(ndet_mask),' detectors out of toal ',num2str(ndet), ' detectors'])
-        disp(['This removes      ',num2str(ndet_mask*ne),' pixels out of total ',num2str(ne*ndet), ' pixels'])
+        disp(['Masked additional ',num2str(ndet_mask),...
+            ' detectors out of toal ',num2str(ndet), ' detectors'])
+        disp(['This removes      ',num2str(ndet_mask*ne),...
+            ' pixels out of total ',num2str(ne*ndet), ' pixels'])
     end
 end
 

--- a/herbert_core/classes/data_loaders/@rundata/rm_masked.m
+++ b/herbert_core/classes/data_loaders/@rundata/rm_masked.m
@@ -23,6 +23,12 @@ if ~exist('ignore_inf','var')
     ignore_inf = true;
 end
 
+if ~(ignore_nan || ignore_inf)
+    S_m= obj.S;
+    Err_m = obj.ERR;
+    det_m = obj.det_par;
+    return    
+end
 
 if ignore_nan && ignore_inf
     index_masked = isnan(obj.S)| isinf(obj.S); % masked pixels
@@ -30,11 +36,6 @@ elseif ignore_nan
     index_masked = isnan(obj.S);
 elseif ignore_inf
     index_masked = isinf(obj.S);
-else
-    S_m= obj.S;
-    Err_m = obj.ERR;
-    det_m = obj.det_par;
-    return
 end
 line_notmasked= ~any(index_masked,1);   % masked detectors (for any energy)
 

--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -218,7 +218,7 @@ classdef rundata
         [ok, mess,this] = isvalid (this);
         % method removes failed (NaN or Inf) data from the data array and deletes
         % detectors, which provided such signal
-        [S_m,Err_m,det_m]=rm_masked(this);
+        [S_m,Err_m,det_m]=rm_masked(this,varargin);
         
         % method sets a field of  lattice if the lattice
         % present and initates the lattice first if it is not present

--- a/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
+++ b/herbert_core/classes/instrument_classes/@oriented_lattice/bmatrix.m
@@ -26,11 +26,10 @@ function [b, arlu, angrlu] = bmatrix(obj)
 
 % Original author: T.G.Perring
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 %
 % Horace v0.1   J. van Duijn, T.G.Perring
 %
 
 angdeg = obj.angdeg;
 alatt  = obj.alatt;
-[b,arlu,angrlu] = bmatrix(alatt,angdeg);;
+[b,arlu,angrlu] = bmatrix(alatt,angdeg);

--- a/herbert_core/classes/instrument_classes/@oriented_lattice/ubmatrix.m
+++ b/herbert_core/classes/instrument_classes/@oriented_lattice/ubmatrix.m
@@ -34,7 +34,6 @@ function [ub,umat] = ubmatrix (obj,varargin)
 
 % Original author: T.G.Perring
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 %
 % Horace v0.1   J. van Duijn, T.G.Perring
 %

--- a/herbert_core/utilities/scientific/bmatrix.m
+++ b/herbert_core/utilities/scientific/bmatrix.m
@@ -29,7 +29,6 @@ function [b, arlu, angrlu, mess] = bmatrix(alatt, angdeg)
 
 % Original author: T.G.Perring
 %
-% $Revision:: 840 ($Date:: 2020-02-10 16:05:56 +0000 (Mon, 10 Feb 2020) $)
 %
 % Horace v0.1   J. van Duijn, T.G.Perring
 if nargout<4

--- a/herbert_core/utilities/scientific/calc_proj_matrix.m
+++ b/herbert_core/utilities/scientific/calc_proj_matrix.m
@@ -3,12 +3,16 @@ function [spec_to_cc, u_to_rlu, spec_to_rlu] = calc_proj_matrix (var1, var2, u, 
 % projection axes defined by u1 || a*, u2 in plane of a* and b* i.e. crystal Cartesian axes
 % Allows for correction scattering plane (omega, dpsi, gl, gs) - see Tobyfit for conventions
 %
+% Mode1:
 %   >> [spec_to_u, u_to_rlu, spec_to_rlu] = ...
 %    calc_proj_matrix (alatt, angdeg, u, v, psi, omega, dpsi, gl, gs)
+
 % or:
+% Mode2:
 %  >>[spec_to_u, u_to_rlu, spec_to_rlu] = ...
-%    calc_proj_matrix (b_matix,u_matrix); - used as part of oriented
-%    lattice function
+%    calc_proj_matrix (b_matix,u_matrix,'','',psi, omega, dpsi, gl, gs);
+%     - used as part of oriented lattice function, deploying parameters,
+%     specified in oriented lattice
 %
 % Input:
 % ------
@@ -27,7 +31,15 @@ function [spec_to_cc, u_to_rlu, spec_to_rlu] = calc_proj_matrix (var1, var2, u, 
 %             into Crystal Catresian coordinate system
 % u_matrix -- transforms vector in crystal Cartesian coords to orthonormal
 %             frame defined by vectors u, v.
-%
+% ''       -- empty u-variable, used to distinguish between mode1 and
+%             mode2
+% v        -- not used in mode 2
+% psi         Angle of u w.r.t. ki (rad)
+% omega       Angle of axis of small goniometer arc w.r.t. notional u
+% dpsi        Correction to psi (rad)
+% gl          Large goniometer arc angle (rad)
+% gs          Small goniometer arc angle (rad)
+
 % Output:
 % -------
 %   spec_to_cc   Matrix (3x3)to convert momentum from coordinates in spectrometer


### PR DESCRIPTION
This small change is related to Horace ticket [#464](https://github.com/pace-neutrons/Horace/issues/464) and enables masking according to keys, e.g. disabling pixels with signal equal to nan or inf