### PR TITLE
Serialise/Deserialise code modified to continue running

### DIFF
--- a/herbert_core/utilities/misc/deserialise.m
+++ b/herbert_core/utilities/misc/deserialise.m
@@ -9,7 +9,7 @@ if use_mex
         return
     catch ME
         if fm
-            rethrow(fm);
+            rethrow(ME);
         else
             warning(ME.identifier,'%s',ME.message);
             use_mex = false;

--- a/herbert_core/utilities/misc/deserialise.m
+++ b/herbert_core/utilities/misc/deserialise.m
@@ -1,9 +1,16 @@
-%Wrapper to handle mex/nomex
-
 function ser = deserialise(a)
-    if get(herbert_config,'use_mex')
+%Wrapper to handle mex/nomex
+%
+use_mex = config_store.instance().get_value('herbert_config','use_mex');
+if use_mex
+    try
         ser = c_deserialise(a);
-    else
-        ser = hlp_deserialise(a);
+        return
+    catch ME
+        warning(ME.identifier,'%s',ME.message)
+        use_mex = false;
     end
+end
+if ~use_mex
+     ser = hlp_deserialise(a);
 end

--- a/herbert_core/utilities/misc/deserialise.m
+++ b/herbert_core/utilities/misc/deserialise.m
@@ -1,16 +1,21 @@
 function ser = deserialise(a)
 %Wrapper to handle mex/nomex
 %
-use_mex = config_store.instance().get_value('herbert_config','use_mex');
+[use_mex,fm] = config_store.instance().get_value('herbert_config',...
+    'use_mex','force_mex_if_use_mex');
 if use_mex
     try
         ser = c_deserialise(a);
         return
     catch ME
-        warning(ME.identifier,'%s',ME.message)
-        use_mex = false;
+        if fm
+            rethrow(fm);
+        else
+            warning(ME.identifier,'%s',ME.message);
+            use_mex = false;
+        end
     end
 end
 if ~use_mex
-     ser = hlp_deserialise(a);
+    ser = hlp_deserialise(a);
 end

--- a/herbert_core/utilities/misc/serialise.m
+++ b/herbert_core/utilities/misc/serialise.m
@@ -8,7 +8,7 @@ if use_mex
         return
     catch ME
         if fm
-            rethrow(fm);
+            rethrow(ME);
         else
             warning(ME.identifier,'%s',ME.message);
             use_mex = false;

--- a/herbert_core/utilities/misc/serialise.m
+++ b/herbert_core/utilities/misc/serialise.m
@@ -1,9 +1,15 @@
-%Wrapper to handle mex/nomex
-
 function ser = serialise(a)
-    if get(herbert_config,'use_mex')
+%Wrapper to handle mex/nomex
+use_mex = config_store.instance().get_value('herbert_config','use_mex');
+if use_mex
+    try
         ser = c_serialise(a);
-    else
-        ser = hlp_serialise(a);
+        return
+    catch ME
+        warning(ME.identifier,'%s',ME.message);
+        use_mex = false;
     end
+end
+if ~use_mex
+    ser = hlp_serialise(a);
 end

--- a/herbert_core/utilities/misc/serialise.m
+++ b/herbert_core/utilities/misc/serialise.m
@@ -1,13 +1,18 @@
 function ser = serialise(a)
 %Wrapper to handle mex/nomex
-use_mex = config_store.instance().get_value('herbert_config','use_mex');
+[use_mex,fm] = config_store.instance().get_value('herbert_config',...
+    'use_mex','force_mex_if_use_mex');
 if use_mex
     try
         ser = c_serialise(a);
         return
     catch ME
-        warning(ME.identifier,'%s',ME.message);
-        use_mex = false;
+        if fm
+            rethrow(fm);
+        else
+            warning(ME.identifier,'%s',ME.message);
+            use_mex = false;
+        end
     end
 end
 if ~use_mex


### PR DESCRIPTION
when mex file is not available. 

Simple modification allows user to continue running the code if mex code for serialiser is not available. This makes the code consistent with all other places where the mex code is used. 

User will be nagged to do something about missing code (disable mex or compile mex)