### PR TITLE
567 lint ignore herbert

### DIFF
--- a/admin/lint_json.m
+++ b/admin/lint_json.m
@@ -9,7 +9,7 @@ function lint_json(filesin, outputfile, varargin)
 %                          if outputfile is empty will write to stdout
 
     p = inputParser;
-    addOptional(p, 'filesin', {['**', filesep, '*.m']});
+    addOptional(p, 'filesin', {['**', filesep, '*.m']}, @iscellstr);
     addOptional(p, 'outputfile', '_screen', @ischar);
     addParameter(p, 'exclude', {}, @iscellstr);
     parse(p, filesin, outputfile, varargin{:});

--- a/cmake/shared/PACE_CodeAnalysis.cmake
+++ b/cmake/shared/PACE_CodeAnalysis.cmake
@@ -2,10 +2,14 @@ add_custom_target(analyse
   COMMENT "Performing code analysis..."
   )
 
+# Handle CMAKE list to matlab cell array
+string(JOIN "','" IGNORE_STRING ${PACE_MLINT_IGNORE})
+string(CONCAT IGNORE_STRING "{'" IGNORE_STRING "'}")
+
 add_custom_target(analyse-mlint
   COMMENT "- Performing MATLAB analysis (Mlint)..."
   BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/mlint.out"
-  COMMAND ${Matlab_MAIN_PROGRAM} -nodisplay -batch "\"addpath('${Herbert_ROOT}/admin');lint_json({'${CMAKE_SOURCE_DIR}/**/*.m'},'${CMAKE_CURRENT_BINARY_DIR}/mlint.json');exit\""
+  COMMAND ${Matlab_MAIN_PROGRAM} -nodisplay -batch "\"addpath('${Herbert_ROOT}/admin');lint_json({'${CMAKE_SOURCE_DIR}/**/*.m'},'${CMAKE_CURRENT_BINARY_DIR}/mlint.json','exclude',${IGNORE_STRING});exit\""
   WORKING_DIRECTORY
   USES_TERMINAL
   )

--- a/cmake/shared/PACE_CodeAnalysis.cmake
+++ b/cmake/shared/PACE_CodeAnalysis.cmake
@@ -1,3 +1,41 @@
+#[=======================================================================[.rst:
+PACE_CodeAnalysis
+-----------------
+
+Run mlint and cppcheck code analysis on Project
+
+Variables required by the module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``${Herbert_ROOT}``
+This is provided by the `FindHerbert` module which must be loaded first
+
+``${PACE_MLINT_IGNORE}``
+
+``${Matlab_MAIN_PROGRAM}``
+This is provided by the `herbert_FindMatlab` module which must be loaded first
+
+Variables defined by the module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``${cppcheck}``
+Location of the CPPCheck executable
+
+Targets defined by the module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``analyse``
+Run full analysis (both cppcheck and mlint if available)
+
+``analyse-mlint``
+Run mlint analysis
+
+``analyse-cppcheck``
+Run cppcheck analysis
+
+#]=======================================================================]
+
+
 add_custom_target(analyse
   COMMENT "Performing code analysis..."
   )
@@ -27,7 +65,9 @@ if (cppcheck)
   add_custom_target(analyse-cppcheck
     COMMENT "- Performing C++ analysis (CppCheck)..."
     BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
-    COMMAND cppcheck --enable=all --inconclusive --xml --xml-version=2 -I "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${CMAKE_SOURCE_DIR}/_LowLevelCode/" 2> "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
+    COMMAND cppcheck --enable=all --inconclusive --xml --xml-version=2
+    -I "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${CMAKE_SOURCE_DIR}/_LowLevelCode/"
+    2> "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
     WORKING_DIRECTORY
     USES_TERMINAL
     )

--- a/cmake/shared/PACE_CodeAnalysis.cmake
+++ b/cmake/shared/PACE_CodeAnalysis.cmake
@@ -4,12 +4,19 @@ add_custom_target(analyse
 
 # Handle CMAKE list to matlab cell array
 string(JOIN "','" IGNORE_STRING ${PACE_MLINT_IGNORE})
-string(CONCAT IGNORE_STRING "{'" ${IGNORE_STRING} "'}")
+
+string(CONCAT RUN_MLINT "\""
+                        "addpath('${Herbert_ROOT}/admin');"
+                        "lint_json({'${CMAKE_SOURCE_DIR}/**/*.m'},"
+                                   "'${CMAKE_CURRENT_BINARY_DIR}/mlint.json',"
+                                   "'exclude',{'${IGNORE_STRING}'});"
+                        "exit;"
+                        "\"")
 
 add_custom_target(analyse-mlint
   COMMENT "- Performing MATLAB analysis (Mlint)..."
   BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/mlint.out"
-  COMMAND ${Matlab_MAIN_PROGRAM} -nodisplay -batch "\"addpath('${Herbert_ROOT}/admin');lint_json({'${CMAKE_SOURCE_DIR}/**/*.m'},'${CMAKE_CURRENT_BINARY_DIR}/mlint.json','exclude',${IGNORE_STRING});exit\""
+  COMMAND ${Matlab_MAIN_PROGRAM} -nodisplay -batch "${RUN_MLINT}"
   WORKING_DIRECTORY
   USES_TERMINAL
   )

--- a/cmake/shared/PACE_CodeAnalysis.cmake
+++ b/cmake/shared/PACE_CodeAnalysis.cmake
@@ -11,6 +11,7 @@ Variables required by the module
 This is provided by the `FindHerbert` module which must be loaded first
 
 ``${PACE_MLINT_IGNORE}``
+CMake list of filepaths or globs describing files to exclude from mlint parsing
 
 ``${Matlab_MAIN_PROGRAM}``
 This is provided by the `herbert_FindMatlab` module which must be loaded first
@@ -66,8 +67,8 @@ if (cppcheck)
     COMMENT "- Performing C++ analysis (CppCheck)..."
     BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
     COMMAND cppcheck --enable=all --inconclusive --xml --xml-version=2
-    -I "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${CMAKE_SOURCE_DIR}/_LowLevelCode/"
-    2> "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
+                     -I "${CMAKE_SOURCE_DIR}/_LowLevelCode/cpp" "${CMAKE_SOURCE_DIR}/_LowLevelCode/"
+                     2> "${CMAKE_CURRENT_BINARY_DIR}/cppcheck.xml"
     WORKING_DIRECTORY
     USES_TERMINAL
     )

--- a/cmake/shared/PACE_CodeAnalysis.cmake
+++ b/cmake/shared/PACE_CodeAnalysis.cmake
@@ -4,7 +4,7 @@ add_custom_target(analyse
 
 # Handle CMAKE list to matlab cell array
 string(JOIN "','" IGNORE_STRING ${PACE_MLINT_IGNORE})
-string(CONCAT IGNORE_STRING "{'" IGNORE_STRING "'}")
+string(CONCAT IGNORE_STRING "{'" ${IGNORE_STRING} "'}")
 
 add_custom_target(analyse-mlint
   COMMENT "- Performing MATLAB analysis (Mlint)..."


### PR DESCRIPTION
Add ability to exclude files from mlint parsing. Syntax
`mlint_json({'files', 'to', 'scan', '**/*.m'}, 'output', 'exclude', {'excluded', 'files', '**/doc_*'});`