### PR TITLE
Herbert master builds failing on null parameter error in Jenkinsfile

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -150,25 +150,30 @@ properties([
       trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The release number of the Matlab to load e.g. R2019b.',
       name: 'MATLAB_VERSION', trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The version of CMake to run the build with. Affects Linux builds only.',
       name: 'CMAKE_VERSION',
       trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The version of GCC to build with. Affects Linux builds only.',
       name: 'GCC_VERSION',
       trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The year of the version of Visual Studio to build with. Affects Windows builds only.',
       name: 'VS_VERSION',
       trim: true
     ),
     string(
+      defaultValue: '',
       description: 'The version of CppCheck tooling to load to provide the code-style checks.',
       name: 'CPPCHECK_VERSION',
       trim: true

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -152,7 +152,8 @@ properties([
     string(
       defaultValue: '',
       description: 'The release number of the Matlab to load e.g. R2019b.',
-      name: 'MATLAB_VERSION', trim: true
+      name: 'MATLAB_VERSION',
+      trim: true
     ),
     string(
       defaultValue: '',


### PR DESCRIPTION
Fix for #322. Should fix the `null parameter` error on the Herbert nightly builds.