### PR TITLE
Horace build flag passed to Herbert in Jenkins

### DIFF
--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -236,7 +236,7 @@ pipeline {
               '''
           } else {
             powershell '''
-           ./tools/build_config/build.ps1 \
+              ./tools/build_config/build.ps1 \
                 -cmake_flags \"-DHerbert_RELEASE_TYPE=\$env:RELEASE_TYPE\" \
                 -matlab_release \$env:MATLAB_VERSION \
                 -vs_version \$env:VS_VERSION \

--- a/tools/build_config/Jenkinsfile
+++ b/tools/build_config/Jenkinsfile
@@ -224,20 +224,20 @@ pipeline {
         script {
           if (isUnix()) {
             sh '''
-          module load cmake/\$CMAKE_VERSION &&
-          module load matlab/\$MATLAB_VERSION &&
-          module load gcc/\$GCC_VERSION &&
-          module load cppcheck/\$CPPCHECK_VERSION &&
-          ./tools/build_config/build.sh \
-            --cmake_flags \"-DHorace_RELEASE_TYPE=\$RELEASE_TYPE\" \
-            --matlab_release \$MATLAB_VERSION \
-            --print_versions \
-            --configure
-          '''
+              module load cmake/\$CMAKE_VERSION &&
+              module load matlab/\$MATLAB_VERSION &&
+              module load gcc/\$GCC_VERSION &&
+              module load cppcheck/\$CPPCHECK_VERSION &&
+              ./tools/build_config/build.sh \
+                --cmake_flags \"-DHerbert_RELEASE_TYPE=\$RELEASE_TYPE\" \
+                --matlab_release \$MATLAB_VERSION \
+                --print_versions \
+                --configure
+              '''
           } else {
             powershell '''
            ./tools/build_config/build.ps1 \
-                -cmake_flags \"-DHorace_RELEASE_TYPE=\$env:RELEASE_TYPE\" \
+                -cmake_flags \"-DHerbert_RELEASE_TYPE=\$env:RELEASE_TYPE\" \
                 -matlab_release \$env:MATLAB_VERSION \
                 -vs_version \$env:VS_VERSION \
                 -print_versions \


### PR DESCRIPTION
Fix the CMake flag in the Jenkinsfile. This flag is important when setting package names. Whilst it was incorrect, nightly packages did not have the date appended to the name.

Addresses #330 