### PR TITLE
Add fallback to getComputerName

### DIFF
--- a/herbert_core/admin/getComputerName.m
+++ b/herbert_core/admin/getComputerName.m
@@ -25,3 +25,8 @@ end
 name = strtrim(lower(name));
 name = strrep(name,'-','_');
 
+if isempty(name)
+    name = 'unknownPC';
+end
+
+end


### PR DESCRIPTION
In case `getComputerName` can't find a name, return unknownPC