### PR TITLE
Fix init bug when no cluster worker

### DIFF
--- a/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_cluster_.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_cluster_.m
@@ -11,8 +11,10 @@ wrkr = which(obj.worker_);
 mff = MPI_clusters_factory.instance();
 
 if isempty(wrkr)
-    error('HERBERT:parallel_config:not_available',...
+    warning('HERBERT:parallel_config:not_available',...
         'Parallel worker is not on the Matlab path so parallel features are not available')
+    config_store.instance().store_config(obj,...
+        'parallel_cluster','none','cluster_config','none');
 else
     known_clusters = mff.known_cluster_names;
     full_cl_name = obj.select_option(known_clusters,cluster_name);


### PR DESCRIPTION
In the initialisation step, there is a [call](https://github.com/pace-neutrons/Herbert/blob/rel_3_5/herbert_core/admin/%40opt_config_manager/opt_config_manager.m#L201) to load a saved configuration (in a local user folder). On first run, however, this file does not exist and instead a default configuration based on a guess of the system type (e.g. `win_small`, `win_large`, `idaas_small` etc). In some cases these defaults enable the MPI cluster to be on *but* the MPI worker `worker_v2.m` is no by default enabled on systems unless the user renames the `worker_v2.m.template`  with correct paths. 

Thus the initialisation fails with an error. Even though it errors, before this it *does* write a configuration file (with the cluster option set to false) and this is subsequently read and the initialisation then runs ok if you do a second `herbert_init`. This is fine (if a bit annoying) for the Matlab version, but for the Python (compiled Matlab) because `herbert_init` is called during the Matlab engine initialisation when this errors the Matlab engine is not deleted and you cannot call `herbert_init` again.

In any case having a lack of worker should not be an error - this is only an error in [`check_and_set_cluster_`](https://github.com/pace-neutrons/Herbert/blob/rel_3_5/herbert_core/classes/MPIFramework/%40parallel_config/private/check_and_set_cluster_.m) - in the similar [`check_and_set_worker_`](https://github.com/pace-neutrons/Herbert/blob/rel_3_5/herbert_core/classes/MPIFramework/%40parallel_config/private/check_and_set_worker_.m) function which is called before `check_and_set_cluster_`, it is a warning. However, the [load configuration routines](https://github.com/pace-neutrons/Herbert/blob/rel_3_5/herbert_core/configuration/%40config_base/config_base.m#L174) just loads from a structure defined for default machine types, and despite the worker field returning a warning which should prevent the cluster field being set, just goes ahead to try to set the cluster field.

This PR changes the cluster setter error to a warning instead.

An alternative implementation is to rework the load configuration code.

-----

To reproduce the bug, delete the existing configuration files (found using `herbert_config`) and run `herbert_init` again on a "large" machine (with more than 32GB memory) - you should see an error.