### PR TITLE
bug in hlp_serial_sise if saveobj has not been overloaded

### DIFF
--- a/herbert_core/utilities/misc/hlp_serial_sise.m
+++ b/herbert_core/utilities/misc/hlp_serial_sise.m
@@ -106,6 +106,7 @@ else
     siz = siz+ data_siz;
 end
 end
+%
 function  siz = serial_sise_itself(v, ~)
 % one for tag;
 siz = v.serial_size()+1;
@@ -131,7 +132,7 @@ if nElem > 0
         try
             % try to use the saveobj method first to get the contents
             conts = arrayfun(@saveobj, v);
-            if isobject(conts) % saveob has not been overloaded
+            if isobject(conts) % saveobj has not been overloaded
                 conts = arrayfun(@struct,v);
             end
         catch 

--- a/herbert_core/utilities/misc/hlp_serial_sise.m
+++ b/herbert_core/utilities/misc/hlp_serial_sise.m
@@ -131,7 +131,10 @@ if nElem > 0
         try
             % try to use the saveobj method first to get the contents
             conts = arrayfun(@saveobj, v);
-        catch
+            if isobject(conts) % saveob has not been overloaded
+                conts = arrayfun(@struct,v);
+            end
+        catch 
             conts = arrayfun(@struct, v);
         end
         conts_siz = hlp_serial_sise(conts);


### PR DESCRIPTION
trivial bug and trivial fix