### PR TITLE
Ensure no empty struct instruments or samples

### DIFF
--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -73,9 +73,9 @@ classdef rundata
         oriented_lattice_ =[];
         
         % instrument model holder;
-        instrument_ = IX_inst();
+        instrument_ = IX_null_inst();
         % sample model holder
-        sample_ = IX_samp();
+        sample_ = IX_null_sample();
         %
         run_id_ = [];
     end
@@ -463,7 +463,7 @@ classdef rundata
             if isa(val,'IX_samp')
                 this.sample_ = val;
             elseif isempty(val)
-                this.sample_  = IX_samp();
+                this.sample_  = IX_null_sample();
             else
                 error('HERBERT:rundata:invalid_argument',...
                     'only instance of IX_samp class can be set as rundata sample. You are setting %s',...

--- a/herbert_core/classes/data_loaders/@rundata/rundata.m
+++ b/herbert_core/classes/data_loaders/@rundata/rundata.m
@@ -447,7 +447,7 @@ classdef rundata
             if isa(val,'IX_inst')
                 this.instrument_ = val;
             elseif isempty(val)
-                this.instrument_  = IX_inst();
+                this.instrument_  = IX_null_inst();
             else
                 error('HERBERT:rundata:invalid_argument',...
                     'only instance of IX_inst class can be set as rundata instrument. You are setting %s',...

--- a/herbert_core/classes/instrument_classes/instrument/@IX_null_sample/IX_null_sample.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_null_sample/IX_null_sample.m
@@ -1,4 +1,4 @@
-classdef IX_null_sample < IX_samp & serializable
+classdef IX_null_sample < IX_samp
     %IX_NULL_SAMPLE Summary of this class goes here
     %   Detailed explanation goes here
     
@@ -7,21 +7,23 @@ classdef IX_null_sample < IX_samp & serializable
     end
     
     methods
-        function ver = classVersion(~)
-            ver = 1;
-        end
         
-        function flds = indepFields(~)
-            flds = {'name','alatt','angdeg'};
-        end
-        
+        % Constructor
+        %------------
         function obj = IX_null_sample()
-            
             obj = obj@IX_samp(''); %[1.0 1.0 1.0],[90 90 90]);
         end
         
+        % ?
+        %-----
         function str = null_struct(~)
             str = struct();
+        end
+        
+        % SERIALIZABLE interface
+        %------------------------------------------------------------------
+        function ver = classVersion(~)
+            ver = 1;
         end
     end
 

--- a/herbert_core/classes/instrument_classes/instrument/@IX_null_sample/IX_null_sample.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_null_sample/IX_null_sample.m
@@ -1,4 +1,4 @@
-classdef IX_null_sample < IX_samp
+classdef IX_null_sample < IX_samp & serializable
     %IX_NULL_SAMPLE Summary of this class goes here
     %   Detailed explanation goes here
     
@@ -7,6 +7,14 @@ classdef IX_null_sample < IX_samp
     end
     
     methods
+        function ver = classVersion(~)
+            ver = 1;
+        end
+        
+        function flds = indepFields(~)
+            flds = {'name','alatt','angdeg'};
+        end
+        
         function obj = IX_null_sample()
             
             obj = obj@IX_samp(''); %[1.0 1.0 1.0],[90 90 90]);

--- a/herbert_core/classes/instrument_classes/instrument/@IX_samp/IX_samp.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_samp/IX_samp.m
@@ -1,4 +1,4 @@
-classdef (Abstract) IX_samp  < matlab.mixin.Heterogeneous
+classdef (Abstract) IX_samp  < matlab.mixin.Heterogeneous & serializable
     % Base class for samples to include the null sample case defined from a
     % struct with no fields (IX_null_sample) and the standard IX_sample
     
@@ -26,6 +26,7 @@ classdef (Abstract) IX_samp  < matlab.mixin.Heterogeneous
     end
     
     methods
+        
         %------------------------------------------------------------------
         % Constructor
         %------------------------------------------------------------------
@@ -40,7 +41,20 @@ classdef (Abstract) IX_samp  < matlab.mixin.Heterogeneous
                 obj.name_ = thename;
             end
         end
-        %
+        
+        % SERIALIZABLE interface
+        %------------------------------------------------------------------
+        function vers = classVersion(~)
+            vers = 0; % base class function, dummy value
+        end
+        
+        function flds = indepFields(~)
+            flds = {'name', 'alatt', 'angdeg'};
+        end
+        
+%
+        % other methods
+        %------------------------------------------------------------------
         function iseq = eq(obj1, obj2)
             iseq = strcmp(obj1.name, obj2.name);
             if numel(obj1.alatt)==3 && numel(obj2.alatt)==3

--- a/herbert_core/classes/instrument_classes/instrument/@IX_samp/IX_samp.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_samp/IX_samp.m
@@ -1,4 +1,4 @@
-classdef IX_samp  < matlab.mixin.Heterogeneous
+classdef (Abstract) IX_samp  < matlab.mixin.Heterogeneous
     % Base class for samples to include the null sample case defined from a
     % struct with no fields (IX_null_sample) and the standard IX_sample
     
@@ -117,7 +117,7 @@ classdef IX_samp  < matlab.mixin.Heterogeneous
         end
     end
     methods(Sealed)
-        %
+        %{
         function is = isempty(obj)
             % Assume that sample is empty if it was created with
             % empty constructor and has not been modified
@@ -136,7 +136,7 @@ classdef IX_samp  < matlab.mixin.Heterogeneous
                 end
             end
         end
-        %
+        %}
     end
     
     %======================================================================

--- a/herbert_core/classes/instrument_classes/instrument/@IX_sample/IX_sample.m
+++ b/herbert_core/classes/instrument_classes/instrument/@IX_sample/IX_sample.m
@@ -40,6 +40,7 @@ classdef IX_sample < IX_samp
     end
 
     methods
+        
         %------------------------------------------------------------------
         % Constructor
         %------------------------------------------------------------------
@@ -157,6 +158,16 @@ classdef IX_sample < IX_samp
             end
         end
 
+        % SERIALIZABLE interface
+        %------------------------------------------------------------------
+        function vers = classVersion(~)
+            vers = 1;
+        end
+        
+        function flds = indepFields(~)
+            flds = {'hall_symbol', 'single_crystal', 'xgeom', 'ygeom', 'shape', 'ps', 'eta', 'temperature'};
+        end
+        
         %------------------------------------------------------------------
         % Set methods
         %

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
@@ -1,4 +1,4 @@
-classdef IX_inst < matlab.mixin.Heterogeneous
+classdef (Abstract) IX_inst < matlab.mixin.Heterogeneous
     % Defines the base instrument class. This superclass must be
     % inherited by all instrument classes to unsure that they are
     % discoverable as instruments using isa(my_obj,'IX_inst')
@@ -287,6 +287,7 @@ classdef IX_inst < matlab.mixin.Heterogeneous
         end
     end
     methods(Sealed)
+        %{
         function is = isempty(obj)
             % Assume that inst is empty if it was created with
             % empty constructor and has not been modified
@@ -306,7 +307,7 @@ classdef IX_inst < matlab.mixin.Heterogeneous
                 end
             end
         end
-        
+        %}
     end
     
     %======================================================================

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst/IX_inst.m
@@ -1,4 +1,4 @@
-classdef (Abstract) IX_inst < matlab.mixin.Heterogeneous
+classdef (Abstract) IX_inst < matlab.mixin.Heterogeneous & serializable
     % Defines the base instrument class. This superclass must be
     % inherited by all instrument classes to unsure that they are
     % discoverable as instruments using isa(my_obj,'IX_inst')
@@ -45,6 +45,18 @@ classdef (Abstract) IX_inst < matlab.mixin.Heterogeneous
             end
         end
         
+        % SERIALIZABLE interface
+        %------------------------------------------------------------------
+        function ver = classVersion(~)
+            ver = 0; % dummy value for abstract base class
+        end
+        
+        function flds = indepFields(~)
+            flds = {'name','source'};
+        end
+        
+        % other methods
+        %------------------
         function iseq = eq(obj1, obj2)
             iseq = strcmp(obj1.name, obj2.name);
             iseq = iseq && obj1.source==obj2.source;

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst_DGdisk/IX_inst_DGdisk.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst_DGdisk/IX_inst_DGdisk.m
@@ -86,8 +86,20 @@ classdef IX_inst_DGdisk < IX_inst
                 end
                 
             end
+
         end
         
+        % SERIALIZABLE interface
+        %---------------------------------------------------------
+        function ver = classVersion(~)
+            ver = 1;
+        end
+
+        function flds = indepFields(~)
+            flds = {'mod_shape_mono','moderator','shaping_chopper','mono_chopper',...
+                    'horiz_div',     'vert_div', 'energy'};
+        end
+
         %------------------------------------------------------------------
         % Set methods for independent properties
         %
@@ -185,6 +197,9 @@ classdef IX_inst_DGdisk < IX_inst
         %------------------------------------------------------------------
     end
     
+    %{
+    % Everything here should now be done by serializable, base class
+    % of IX_inst, base class of this function.
     %======================================================================
     % Methods for fast construction of structure with independent properties
     methods (Static, Access = private)
@@ -428,6 +443,7 @@ classdef IX_inst_DGdisk < IX_inst
         %------------------------------------------------------------------
         
     end
+    %}
     %======================================================================
     
 end

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst_DGfermi/IX_inst_DGfermi.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_inst_DGfermi/IX_inst_DGfermi.m
@@ -81,7 +81,16 @@ classdef IX_inst_DGfermi < IX_inst
                 
             end
         end
+
+        % SERIALIZABLE interface
+        %-----------------------------------------------------------
+        function ver = classVersion(~)
+            ver = 1;
+        end
         
+        function flds = indepFields(~)
+            flds = {'moderator','aperture', 'fermi_chopper', 'energy'};
+        end
         %------------------------------------------------------------------
         % Set methods for independent properties
         %
@@ -156,7 +165,7 @@ classdef IX_inst_DGfermi < IX_inst
         %------------------------------------------------------------------
     end
     
-    
+    %{ Methods below should all have been replaced by base class serializable in IX_inst
     %======================================================================
     % Methods for fast construction of structure with independent properties
     methods (Static, Access = private)
@@ -400,6 +409,7 @@ classdef IX_inst_DGfermi < IX_inst
         %------------------------------------------------------------------
         
     end
+    %}
     %======================================================================
     
 end

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_null_inst/IX_null_inst.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_null_inst/IX_null_inst.m
@@ -1,4 +1,4 @@
-classdef IX_null_inst < IX_inst & serializable
+classdef IX_null_inst < IX_inst 
     % An instrument constructed from a struct with no fields
     % As the new Experiment class has an array of IX_inst, we need
     % something derived from IX_inst to hold the case where the file from
@@ -10,24 +10,25 @@ classdef IX_null_inst < IX_inst & serializable
     end
     
     methods
-        function ver = classVersion(~)
-            ver = 1;
-        end
-        
-        function flds = indepFields(~)
-            flds = {'name','source'};
-        end
-        
-
-        
+    
+        % Constructor
+        %-------------------------------
         function obj = IX_null_inst()
             % constructs a vanilla instance based on IX_inst
             obj = obj@IX_inst();
         end
         
+        % ?
+        %------
         function str = null_struct(~)
             %makes the null struct for storage in a file
             str = struct();
+        end
+        
+        % SERIALIZABLE interface
+        %------------------------------------------------------------------
+        function ver = classVersion(~)
+            ver = 1;
         end
     end
 

--- a/herbert_core/classes/instrument_classes/instrument/instruments/@IX_null_inst/IX_null_inst.m
+++ b/herbert_core/classes/instrument_classes/instrument/instruments/@IX_null_inst/IX_null_inst.m
@@ -1,4 +1,4 @@
-classdef IX_null_inst < IX_inst
+classdef IX_null_inst < IX_inst & serializable
     % An instrument constructed from a struct with no fields
     % As the new Experiment class has an array of IX_inst, we need
     % something derived from IX_inst to hold the case where the file from
@@ -10,6 +10,16 @@ classdef IX_null_inst < IX_inst
     end
     
     methods
+        function ver = classVersion(~)
+            ver = 1;
+        end
+        
+        function flds = indepFields(~)
+            flds = {'name','source'};
+        end
+        
+
+        
         function obj = IX_null_inst()
             % constructs a vanilla instance based on IX_inst
             obj = obj@IX_inst();


### PR DESCRIPTION
There have been 2 alternative paradigms used for instruments and samples that were not defined. One was to use an empty class object (with isempty redefined to check no fields used) and one was to use IX_null versions of the instrument and sample classes if not definition was provided. This alteration enables the latter paradigm, and also makes the base classes IX_inst and IX_samp abstract to prevent their use for creating objects. The IX_null classes have also been made (in Alex' sense) serializable.

Additional changes have been made to make the tests run.

This may break Horace which has not yet been updated to fit.