### PR TITLE
loop if more than one plot

### DIFF
--- a/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
+++ b/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
@@ -113,18 +113,9 @@ classdef IX_data_1d < IX_dataset
                       ['array of IX_data_1d has more than 2 dimensions, ' ...
                       'and cannot be used with calc_continuous_fraction']);
             end
-            frac = +2.0; % >1 so enough to trigger fr<frac on any pass below
-            n_points = 0;
-            sz = size(obj);
-            for i = 1:sz(1)
-                for j = 1:sz(2)
-                    [fr,np] = calc_cont_frac_(obj(i,j));
-                    if fr<frac
-                        frac = fr;
-                        n_points = np;
-                    end
-                end
-            end
+            [fr,np] = arrayfun(@calc_cont_frac_, obj);
+            [frac, ind] = min(fr);
+            n_points = np(ind);
         end
     end
     %======================================================================

--- a/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
+++ b/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
@@ -113,7 +113,7 @@ classdef IX_data_1d < IX_dataset
                       ['array of IX_data_1d has more than 2 dimensions, ' ...
                       'and cannot be used with calc_continuous_fraction']);
             end
-            frac = +1.0;
+            frac = +2.0; % >1 so enough to trigger fr<frac on any pass below
             n_points = 0;
             sz = size(obj);
             for i = 1:sz(1)

--- a/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
+++ b/herbert_core/utilities/classes/@IX_data_1d/IX_data_1d.m
@@ -95,13 +95,36 @@ classdef IX_data_1d < IX_dataset
             % be 2,3, and points 1 and 4 are not displaying if you are
             % plotting a line. Such dataset contains 4 points, only two
             % would be plotted by pl, so the function returns frac = 2/4 = 0.5;
+            % If more than one plot is passed in obj as an array, then the
+            % minimum frac value over all plots and the corresponding point
+            % number is returned.
+            %
+            % Up to 2 dimensions of plots are supported but higher numbers
+            % will error.
             %
             % Returns:
             % frac  -- fraction of the points to be plotted out of all
             % n_points -- number of points containing information (not NaN-s)
             %
             
-            [frac,n_points] = calc_cont_frac_(obj);
+            nd = ndims(obj);
+            if nd>2
+                error('HERBERT:IX_data_1d:calc_continuous_fraction', ...
+                      ['array of IX_data_1d has more than 2 dimensions, ' ...
+                      'and cannot be used with calc_continuous_fraction']);
+            end
+            frac = +1.0;
+            n_points = 0;
+            sz = size(obj);
+            for i = 1:sz(1)
+                for j = 1:sz(2)
+                    [fr,np] = calc_cont_frac_(obj(i,j));
+                    if fr<frac
+                        frac = fr;
+                        n_points = np;
+                    end
+                end
+            end
         end
     end
     %======================================================================

--- a/herbert_core/utilities/classes/@IX_data_1d/private/calc_cont_frac_.m
+++ b/herbert_core/utilities/classes/@IX_data_1d/private/calc_cont_frac_.m
@@ -8,7 +8,7 @@ function [frac,n_points] = calc_cont_frac_(obj)
 % would be plotted by pl, so the function returns frac = 2/4 = 0.5;
 %
 % Returns:
-% frac  -- fraction of the points to be plotted out of all
+% frac  -- fraction of the points to be plotted out of all valid points (not-NaN)
 % n_points -- number of points containing information (not NaN-s)
 
 if ~obj.valid_


### PR DESCRIPTION
For IX_data_1d, the function calc_continuous_fraction as implemented in the private function calc_cont_frac_, scans a single plot for points which cannot be plotted because although their value is plottable, the values either side are NaN and so lines cannot be drawn from the plottable point.

In the tests in test_tobyfit, calls to this function with one such plot work fine. However there are IX_data_1d objects with three plots in them, and they fail because the first line of calc_cont_frac_ fails - ~valid has too many arguments (it says). This PR fixes the behaviour.

As modified here the parent call calc_continuous_fraction now loops over the component plots, returns the corresponding fraction, and reports to the caller the minimum fraction of the set. This minimizes the changes required to run the tests.
