### PR TITLE
serializable bug

### DIFF
--- a/_test/test_serializers/serializableTester1.m
+++ b/_test/test_serializers/serializableTester1.m
@@ -6,7 +6,6 @@ classdef serializableTester1 < serializable
         Prop_level1_1=10;
         Prop_level1_2 =20;
         Prop_level1_3 = 'new_value'
-        class_version_ = 2;
     end
 
     methods
@@ -17,6 +16,17 @@ classdef serializableTester1 < serializable
         function obj = loadobj(S)
             obj = serializableTester1();
             obj = loadobj@serializable(S,obj);
+        end
+        function ver = ver_holder(new_version)
+            persistent version;
+            if isempty(version)
+                version = serializableTester1.class_version_;
+            end
+            if nargin > 0
+                version = new_version;
+            end
+
+            ver = version;
         end
     end
 
@@ -31,10 +41,13 @@ classdef serializableTester1 < serializable
         end
         % get class version, which would affect the way class is stored on/
         % /restore from an external media
-        function ver  = classVersion(obj)
-            ver = obj(1).class_version_;
+        function ver  = classVersion(~)
+           ver = serializableTester1.ver_holder();
         end
 
+    end
+    properties(Constant,Access=private)
+        class_version_ = 2;
     end
     properties(Constant,Access=protected)
         fields_to_save_ = {'Prop_level1_1','Prop_level1_2','Prop_level1_3'};

--- a/_test/test_serializers/serializableTester1.m
+++ b/_test/test_serializers/serializableTester1.m
@@ -1,12 +1,14 @@
 classdef serializableTester1 < serializable
     % Class used as test bench to unittest serializable class
     %
-    
+
     properties
         Prop_level1_1=10;
         Prop_level1_2 =20;
+        Prop_level1_3 = 'new_value'
+        class_version_ = 2;
     end
-    
+
     methods
         function obj = serializableTester1()
         end
@@ -17,21 +19,38 @@ classdef serializableTester1 < serializable
             obj = loadobj@serializable(S,obj);
         end
     end
-    
+
     methods(Access=public)
         % get independent fields, which fully define the state of the object
-        function flds = indepFields(~)
-            flds = serializableTester1.fields_to_save_;
+        function flds = indepFields(obj)
+            if obj(1).class_version_ == 1
+                flds = serializableTester1.fields_to_save_(1:2);
+            else
+                flds = serializableTester1.fields_to_save_;
+            end
         end
         % get class version, which would affect the way class is stored on/
         % /restore from an external media
-        function ver  = classVersion(~)
-            ver = 1;
+        function ver  = classVersion(obj)
+            ver = obj(1).class_version_;
         end
-        
+
     end
     properties(Constant,Access=protected)
-        fields_to_save_ = {'Prop_level1_1','Prop_level1_2'};
+        fields_to_save_ = {'Prop_level1_1','Prop_level1_2','Prop_level1_3'};
+    end
+    methods(Access=protected)
+        function obj = from_old_struct(obj,inputs)
+            if (isfield(inputs,'version') && inputs(1).version ~= 2) || ...
+                ~isfield(inputs,'version')
+                obj = from_bare_struct(obj,inputs);
+                for i=1:numel(obj)
+                    obj(i).Prop_level1_3 = 'recovered_new_from_old_value';
+                end
+            else
+                obj = from_old_struct@serializable(obj,inputs);
+            end
+        end
     end
 end
 

--- a/_test/test_serializers/test_serializable_class.m
+++ b/_test/test_serializers/test_serializable_class.m
@@ -3,7 +3,7 @@ classdef test_serializable_class < TestCase
         wk_dir = tmp_dir()
     end
     methods
-        
+
         function obj = test_serializable_class(name)
             if ~exist('name', 'var')
                 name = 'test_serializable_class ';
@@ -31,9 +31,9 @@ classdef test_serializable_class < TestCase
             % Serialize using Matlab
             ser =  hlp_serialise(serCl);
             serCl_rec = hlp_deserialise(ser);
-            
+
             assertEqual(serCl, serCl_rec)
-            
+
             size = hlp_serial_sise(serCl);
             assertEqual(size,numel(ser));
             %--------------------------------------------------------------
@@ -44,10 +44,10 @@ classdef test_serializable_class < TestCase
             end
             ser_c     = c_serialise(serCl);
             serCl_rec = c_deserialise(ser_c);
-            
+
             assertEqual(serCl, serCl_rec)
             assertEqual(ser_c,ser);
-            
+
             size_c = c_serial_size(serCl);
             assertEqual(size_c,numel(ser));
         end
@@ -72,9 +72,9 @@ classdef test_serializable_class < TestCase
             % Serialize using Matlab
             ser =  hlp_serialise(serCl);
             serCl_rec = hlp_deserialise(ser);
-            
+
             assertEqual(serCl, serCl_rec)
-            
+
             size = hlp_serial_sise(serCl);
             assertEqual(size,numel(ser));
             %--------------------------------------------------------------
@@ -85,14 +85,14 @@ classdef test_serializable_class < TestCase
             end
             ser_c     = c_serialise(serCl);
             serCl_rec = c_deserialise(ser_c);
-            
+
             assertEqual(serCl, serCl_rec)
             assertEqual(ser_c,ser);
-            
+
             size_c = c_serial_size(serCl);
             assertEqual(size_c,numel(ser));
         end
-        
+
         function test_ser_serializeble_obj_array_level1(obj)
             conf = herbert_config;
             ds = conf.get_data_to_store();
@@ -110,29 +110,29 @@ classdef test_serializable_class < TestCase
             % Serialize using Matlab
             ser =  hlp_serialise(serCl);
             serCl_rec = hlp_deserialise(ser);
-            
+
             assertEqual(serCl, serCl_rec)
-            
+
             size = hlp_serial_sise(serCl);
             assertEqual(size,numel(ser));
             %--------------------------------------------------------------
             % Serialize using C++
-            
+
             skipTest('C++ serializers crashes over arrays of objects #394')
             if ~obj.use_mex
                 skipTest('Mex mode is not currently available for: test_ser_serializeble_obj_array');
             end
             size_c = c_serial_size(serCl);
             assertEqual(size_c,size);
-            
+
             ser_c     = c_serialise(serCl);
             assertEqual(ser,ser_c);
             %
             serCl_rec = c_deserialise(ser_c);
-            
+
             assertEqual(serCl, serCl_rec)
             assertEqual(ser_c,ser);
-            
+
             size_c = c_serial_size(serCl);
             assertEqual(size_c,numel(ser));
         end
@@ -146,19 +146,19 @@ classdef test_serializable_class < TestCase
             serCl = serializableTester2();
             serCl.Prop_level2_1=100;
             serCl.Prop_level2_2= serializableTester1();
-            
+
             %--------------------------------------------------------------
-            
+
             ser =  hlp_serialise(serCl);
             size = hlp_serial_sise(serCl);
             assertEqual(size,numel(ser));
             [cerCl_rec,nbytes] = hlp_deserialise(ser);
-            
+
             assertEqual(nbytes,numel(ser));
             assertEqual(serCl, cerCl_rec)
             assertTrue(isa(cerCl_rec.Prop_level2_2,class(serCl.Prop_level2_2)));
-            
-            
+
+
             skipTest('C++ deserializer does not work propertly; #394')
             if ~obj.use_mex
                 skipTest('Mex mode is not currently available for: test_ser_serializeble_obj');
@@ -166,18 +166,18 @@ classdef test_serializable_class < TestCase
             %--------------------------------------------------------------
             % Serialize using C++
             size_c = c_serial_size(serCl);
-            
+
             ser_c     = c_serialise(serCl);
             assertEqual(ser_c,ser)
-            
+
             [serCl_rec,nbytes] = c_deserialise(ser_c);
-            
+
             %
             assertEqual(nbytes,numel(ser_c))
             assertEqual(serCl, serCl_rec)
             assertTrue(isa(cerCl_rec.Prop_level2_2,class(serCl.Prop_level2_2)));
             assertEqual(ser_c,ser);
-            
+
             assertEqual(size_c,numel(ser));
         end
         %
@@ -190,20 +190,20 @@ classdef test_serializable_class < TestCase
             serCl = serializableTester2();
             serCl.Prop_level2_1=100;
             serCl.Prop_level2_2= [1,2,4];
-            
+
             %--------------------------------------------------------------
-            
+
             ser =  hlp_serialise(serCl);
             size = hlp_serial_sise(serCl);
             assertEqual(size,numel(ser));
-            
+
             [cerCl_rec,nbytes] = hlp_deserialise(ser);
-            
+
             assertEqual(nbytes,numel(ser));
             assertEqual(serCl, cerCl_rec)
             assertTrue(isa(cerCl_rec.Prop_level2_2,class(serCl.Prop_level2_2)));
-            
-            
+
+
             skipTest('C++ deserializer does not work propertly; #394')
             if ~obj.use_mex
                 skipTest('Mex mode is not currently available for: test_ser_serializeble_obj');
@@ -211,20 +211,45 @@ classdef test_serializable_class < TestCase
             %--------------------------------------------------------------
             % Serialize using C++
             size_c = c_serial_size(serCl);
-            
+
             ser_c     = c_serialise(serCl);
             assertEqual(ser_c,ser)
-            
+
             [serCl_rec,nbytes] = c_deserialise(ser_c);
-            
+
             %
             assertEqual(nbytes,numel(ser_c))
             assertEqual(serCl, serCl_rec)
             assertTrue(isa(cerCl_rec.Prop_level2_2,class(serCl.Prop_level2_2)));
             assertEqual(ser_c,ser);
-            
+
             assertEqual(size_c,numel(ser));
         end
+        function test_new_version_saveobj_loadobj_old_version(~)
+            % prepare reference data
+            tc = serializableTester2();
+            tc2 = serializableTester1();
+            tc2.class_version_ = 1;
+            tc.Prop_level2_1 = 10;
+            tc.Prop_level2_2 = repmat(tc2,1,2);
+
+            % prepara data to store
+            tc_struct = saveobj(tc);
+
+            % recover data stored as old version using new version class
+            tc_rec = serializableTester2.loadobj(tc_struct);
+            % check successful recovery
+
+            tc2_lev2 = tc_rec.Prop_level2_2;
+
+            assertEqual(tc2_lev2(1).class_version_,2);
+            assertEqual(tc2_lev2(1).Prop_level1_3,'recovered_new_from_old_value');
+
+            assertEqual(tc2_lev2(2).class_version_,2);
+            assertEqual(tc2_lev2(2).Prop_level1_3,'recovered_new_from_old_value');
+
+        end
+
         %
         function test_new_version_saveobj_loadobj_array_recursive(~)
             % prepare reference data
@@ -237,11 +262,11 @@ classdef test_serializable_class < TestCase
             end
             % prepara data to store
             tc_struct = saveobj(tc);
-            
+
             % modify the class version assuming new class version appeared
             ver = serializableTester2.version_holder();
             serializableTester2.version_holder(ver+1);
-            
+
             % recover data stored as old version using new version class
             tc_rec = serializableTester2.loadobj(tc_struct);
             % check successful recovery
@@ -258,13 +283,13 @@ classdef test_serializable_class < TestCase
                 tc(i).Prop_level1_1 = i*10;
                 tc(i).Prop_level1_2 = repmat(tc2,1,2*i);
             end
-            
+
             tc_bytes = tc.serialize();
             tc_size  = tc.serial_size();
             assertEqual(numel(tc_bytes),tc_size);
-            
+
             [tc_rec,nbytes] = serializable.deserialize(tc_bytes);
-            
+
             assertEqual(size(tc_rec),size(tc));
             assertEqual(tc_size,nbytes);
             for i=1:numel(tc)
@@ -274,8 +299,8 @@ classdef test_serializable_class < TestCase
                     class(tc_rec(i).Prop_level1_2));
             end
         end
-        
-        
+
+
         function test_to_from_to_struct_classes_array_recursive(~)
             tc = serializableTester1();
             tc = repmat(tc,2,2);
@@ -285,14 +310,14 @@ classdef test_serializable_class < TestCase
                 tc(i).Prop_level1_2 = repmat(tc2,1,2*i);
             end
             tc_struct = to_struct(tc);
-            
+
             tc_rec = serializable.from_struct(tc_struct);
             assertEqual(size(tc_rec),size(tc));
             for i=1:numel(tc)
                 assertEqual(tc(i),tc_rec(i));
             end
         end
-        
+
         function test_save_load_single_class(obj)
             tc = serializableTester1();
             tc.Prop_level1_1 = 20;
@@ -301,20 +326,20 @@ classdef test_serializable_class < TestCase
             clob = onCleanup(@()delete(test_file));
             save(test_file,'tc');
             ld_dat = load(test_file);
-            
+
             assertEqual(tc,ld_dat.tc);
         end
-        
+
         function test_saveobj_loadobj_single_class(~)
             tc = serializableTester1();
             tc.Prop_level1_1 = 20;
             tc.Prop_level1_2 = cell(1,10);
             tc_struct = saveobj(tc);
-            
+
             tc_rec = serializableTester1.loadobj(tc_struct);
             assertEqual(tc,tc_rec);
         end
-        
+
         function test_serialize_classes_array(~)
             tc = serializableTester1();
             tc = repmat(tc,2,2);
@@ -322,16 +347,16 @@ classdef test_serializable_class < TestCase
                 tc(i).Prop_level1_1 = i*10;
                 tc(i).Prop_level1_2 = cell(1,2*i);
             end
-            
+
             tc_bytes = tc.serialize();
             tc_size  = tc.serial_size();
             assertEqual(numel(tc_bytes),tc_size);
-            
+
             [tc_rec,nbytes] = serializable.deserialize(tc_bytes);
             assertEqual(tc,tc_rec);
             assertEqual(tc_size,nbytes);
         end
-        
+
         function test_to_from_to_struct_classes_array(~)
             tc = serializableTester1();
             tc = repmat(tc,2,2);
@@ -340,7 +365,7 @@ classdef test_serializable_class < TestCase
                 tc(i).Prop_level1_2 = cell(1,2*i);
             end
             tc_struct = to_struct(tc);
-            
+
             tc_rec = serializable.from_struct(tc_struct);
             assertEqual(size(tc_rec),size(tc));
             for i=1:numel(tc)
@@ -351,22 +376,22 @@ classdef test_serializable_class < TestCase
             tc = serializableTester1();
             tc.Prop_level1_1 = 20;
             tc.Prop_level1_2 = cell(1,10);
-            
+
             tc_bytes = tc.serialize();
             tc_size  = tc.serial_size();
             assertEqual(numel(tc_bytes),tc_size);
-            
+
             [tc_rec,nbytes] = serializable.deserialize(tc_bytes);
             assertEqual(tc,tc_rec);
             assertEqual(tc_size,nbytes);
         end
-        
+
         function test_to_from_to_struct_single_class(~)
             tc = serializableTester1();
             tc.Prop_level1_1 = 20;
             tc.Prop_level1_2 = cell(1,10);
             tc_struct = to_struct(tc);
-            
+
             tc_rec = serializable.from_struct(tc_struct);
             assertEqual(tc,tc_rec);
         end

--- a/_test/test_serializers/test_serializable_class.m
+++ b/_test/test_serializers/test_serializable_class.m
@@ -225,29 +225,34 @@ classdef test_serializable_class < TestCase
 
             assertEqual(size_c,numel(ser));
         end
-        function test_new_version_saveobj_loadobj_old_version(~)
+        function test_saveobj_old_version_loadobj_new_version(~)
             % prepare reference data
             tc = serializableTester2();
             tc2 = serializableTester1();
-            tc2.class_version_ = 1;
+            % we have old version object
+            tc2.ver_holder(1);
+            assertEqual(tc2.classVersion(),1);
+
             tc.Prop_level2_1 = 10;
             tc.Prop_level2_2 = repmat(tc2,1,2);
 
-            % prepara data to store
+            % store old verision object on level 2
             tc_struct = saveobj(tc);
 
+            % now we have rebuild the object to have new version
+            tc2.ver_holder(2);            
             % recover data stored as old version using new version class
             tc_rec = serializableTester2.loadobj(tc_struct);
             % check successful recovery
 
             tc2_lev2 = tc_rec.Prop_level2_2;
 
-            assertEqual(tc2_lev2(1).class_version_,2);
+            assertEqual(tc2_lev2(1).classVersion(),2);
             assertEqual(tc2_lev2(1).Prop_level1_3,'recovered_new_from_old_value');
 
-            assertEqual(tc2_lev2(2).class_version_,2);
+            assertEqual(tc2_lev2(2).classVersion(),2);
             assertEqual(tc2_lev2(2).Prop_level1_3,'recovered_new_from_old_value');
-
+            %
         end
 
         %

--- a/_test/test_serializers/test_serialize.m
+++ b/_test/test_serializers/test_serialize.m
@@ -15,7 +15,7 @@ classdef test_serialize < TestCaseWithSave
         
         
         %------------------------------------------------------------------
-        function test_ser_sample(obj)
+        function test_ser_sample(~)
             sam1=IX_sample('',true,[1,1,0],[0,0,1],'cuboid',[0.04,0.03,0.02]);
             
             bytes1 = hlp_serialize(sam1);
@@ -112,7 +112,7 @@ classdef test_serialize < TestCaseWithSave
             assertEqual(nbytes,numel(ser));
         end
         
-        function test_ser_serializeble_obj_array_level1(obj)
+        function test_ser_serializeble_obj_array_level1(~)
             % Prepare data
             serCl = serializableTester1();
             serCl = repmat(serCl,2,2);
@@ -148,7 +148,7 @@ classdef test_serialize < TestCaseWithSave
             assertTrue(isa(cerCl_rec.Prop_level2_2,class(serCl.Prop_level2_2)));
         end
         %
-        function test_ser_serializeble_obj_level0(obj)
+        function test_ser_serializeble_obj_level0(~)
             %--------------------------------------------------------------
             serCl = serializableTester2();
             serCl.Prop_level2_1=100;

--- a/_test/test_utilities/test_parse_args_namelist.m
+++ b/_test/test_utilities/test_parse_args_namelist.m
@@ -7,7 +7,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_1 (self)
+        function test_1 (~)
             namelist = {'name','target','targ','frequency'};
             [S, present] = parse_args_namelist (namelist, '-targ',37);
             
@@ -19,7 +19,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_2 (self)
+        function test_2 (~)
             namelist = {'name','target','targ','frequency'};
             [S, present] = parse_args_namelist (namelist, 'hello',42);
             
@@ -32,7 +32,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_3 (self)
+        function test_3 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 42,'-name','hello');
@@ -46,7 +46,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_4 (self)
+        function test_4 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 'hello',42);
@@ -60,7 +60,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_5 (self)
+        function test_5 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 42);
@@ -73,7 +73,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_6 (self)
+        function test_6 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 42, 'parp', {23,'toot'});
@@ -88,7 +88,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_7 (self)
+        function test_7 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 42, 'parp', {23,'toot'});
@@ -103,7 +103,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_8 (self)
+        function test_8 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             [S, present] = parse_args_namelist (namelist_with_opt,...
@@ -120,7 +120,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_9 (self)
+        function test_9 (~)
             namelist = {'name','target','targ','frequency'};
             namelist_with_opt = {namelist,{'char'}};
             try
@@ -134,7 +134,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_10 (self)
+        function test_10 (~)
             namelist = {'name','sx','targ','frequency'};
             namelist_with_opt = {namelist,{'char','lognumscalar'}};
             [S, present] = parse_args_namelist (namelist_with_opt, '-targ',37);
@@ -147,7 +147,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_11 (self)
+        function test_11 (~)
             namelist = {'name','sx','targ','frequency'};
             namelist_with_opt = {namelist,{'char','lognumscalar'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 1, '-targ',37);
@@ -161,7 +161,7 @@ classdef test_parse_args_namelist < TestCaseWithSave
         end
         
         %--------------------------------------------------------------------------
-        function test_12 (self)
+        function test_12 (~)
             namelist = {'name','sx','targ','frequency'};
             namelist_with_opt = {namelist,{'char','lognumscalar'}};
             [S, present] = parse_args_namelist (namelist_with_opt, 'thing', '-targ',37);

--- a/herbert_core/utilities/classes/@serializable/private/from_bare_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/from_bare_struct_.m
@@ -1,4 +1,4 @@
-function obj = from_class_struct_(obj,inputs)
+function obj = from_bare_struct_(obj,inputs)
 % Restore object from the fields, previously obtained by to_struct method
 %
 % Input:
@@ -31,7 +31,7 @@ end
 for i=1:nobj
     obj(i) = set_obj(obj(i),inputs(i),fields_to_set);
 end
-end % function from_class_struct_
+end % function from_bare_struct_
 %
 function obj = set_obj(obj,inputs,flds)
 for i=1:numel(flds)

--- a/herbert_core/utilities/classes/@serializable/private/from_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/from_struct_.m
@@ -15,8 +15,16 @@ end
 class_name = inputs.serial_name;
 %
 obj = feval(class_name);
-if isfield(inputs,'array_dat')
-    obj = obj.from_class_struct(inputs.array_dat);
+if isfield(inputs,'version')
+    if inputs.version == obj.classVersion()
+        if isfield(inputs,'array_dat')
+            obj = obj.from_bare_struct(inputs.array_dat);
+        else
+            obj = obj.from_bare_struct(inputs);
+        end        
+    else
+        obj = obj.from_old_struct(inputs);
+    end
 else
-    obj = obj.from_class_struct(inputs);
+    obj = obj.from_old_struct(inputs);
 end

--- a/herbert_core/utilities/classes/@serializable/private/loadobj_.m
+++ b/herbert_core/utilities/classes/@serializable/private/loadobj_.m
@@ -36,7 +36,13 @@ if isfield(S,'version')
             obj = obj.from_bare_struct(S);
         end
     else
-        obj = obj.from_old_struct(S);
+        % let's assume that old structure do not want to recover from
+        % array?
+        if isfield(S,'array_dat')
+            obj = obj.from_old_struct(S.array_dat);            
+        else
+            obj = obj.from_old_struct(S);
+        end
     end
 else % previous version(s), written without version info or any old version
     obj = obj.from_old_struct(S);

--- a/herbert_core/utilities/classes/@serializable/private/loadobj_.m
+++ b/herbert_core/utilities/classes/@serializable/private/loadobj_.m
@@ -31,9 +31,9 @@ ver_requested = obj.classVersion();
 if isfield(S,'version')
     if S.version == ver_requested
         if isfield(S,'array_dat')
-            obj = obj.from_class_struct(S.array_dat);
+            obj = obj.from_bare_struct(S.array_dat);
         else
-            obj = obj.from_class_struct(S);
+            obj = obj.from_bare_struct(S);
         end
     else
         obj = obj.from_old_struct(S);

--- a/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
@@ -1,4 +1,4 @@
-function struc = to_bare_struct_(obj,recursively)
+function struc = to_bare_struct_(obj,recursively,add_version_to_subobjects)
 % Convert serializable object into a special structure, which allow
 % serialization and recovery using from_bare_struct operation
 %
@@ -7,9 +7,15 @@ function struc = to_bare_struct_(obj,recursively)
 %        the fields to use
 % recursively -- if true, all serializable subobjects of the
 %                class are converted to bare structure,
+% add_version_to_subobjects -- if true, add class version to 
+%                serializable subobjects, which are the children of the
+%                current class version
 % Returns:
 % struc -- structure, containing information, fully defining the
 %          serializabe class
+if ~exist('add_version_to_subobjects','var')
+    add_version_to_subobjects = false;
+end
 flds = indepFields(obj);
 
 cell_dat = cell(numel(flds),numel(obj));
@@ -21,7 +27,7 @@ for j=1:numel(obj)
             if recursively
                 val= to_bare_struct_(val,recursively);
             else
-                val= to_struct(val);
+                val= to_struct(val,add_version_to_subobjects);
             end
         end
         cell_dat{i,j} = val;

--- a/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
@@ -1,6 +1,6 @@
 function struc = to_bare_struct_(obj,recursively)
 % Convert serializable object into a special structure, which allow
-% serialization and recovery using from_class_struct operation
+% serialization and recovery using from_bare_struct operation
 %
 % Inputs:
 % obj -- the instance of the object to convert to a structure.

--- a/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_bare_struct_.m
@@ -1,4 +1,4 @@
-function struc = to_bare_struct_(obj,recursively,add_version_to_subobjects)
+function struc = to_bare_struct_(obj,recursively)
 % Convert serializable object into a special structure, which allow
 % serialization and recovery using from_bare_struct operation
 %
@@ -13,9 +13,6 @@ function struc = to_bare_struct_(obj,recursively,add_version_to_subobjects)
 % Returns:
 % struc -- structure, containing information, fully defining the
 %          serializabe class
-if ~exist('add_version_to_subobjects','var')
-    add_version_to_subobjects = false;
-end
 flds = indepFields(obj);
 
 cell_dat = cell(numel(flds),numel(obj));
@@ -27,7 +24,7 @@ for j=1:numel(obj)
             if recursively
                 val= to_bare_struct_(val,recursively);
             else
-                val= to_struct(val,add_version_to_subobjects);
+                val= to_struct(val);
             end
         end
         cell_dat{i,j} = val;

--- a/herbert_core/utilities/classes/@serializable/private/to_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_struct_.m
@@ -1,4 +1,4 @@
-function struc = to_struct_(obj,add_version)
+function struc = to_struct_(obj)
 % Convert serializable object into a special structure, which allow
 % serialization and recovery using static "serializable.from_struct"
 % operation.
@@ -6,20 +6,16 @@ function struc = to_struct_(obj,add_version)
 % Inputs:
 % obj         -- the instance of the object to convert to a structure.
 %                the fields to use
-% add_version -- if true, add version field to serializable subobjects
-%                and the structure itself
 % 
 % Returns:
 % struc -- structure, containing information, fully defining the
 %          serializabe class
 
-struc = to_bare_struct_(obj,false,add_version);
+struc = to_bare_struct_(obj,false);
 if numel(obj)>1
     struc = struct('serial_name',class(obj),...
         'array_dat',struc);
 else
     struc.serial_name = class(obj);
 end
-if add_version
-    struc.version = obj.classVersion();
-end
+struc.version = obj.classVersion();

--- a/herbert_core/utilities/classes/@serializable/private/to_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_struct_.m
@@ -4,16 +4,16 @@ function struc = to_struct_(obj,add_version)
 % operation.
 %
 % Inputs:
-% obj -- the instance of the object to convert to a structure.
-%        the fields to use
+% obj         -- the instance of the object to convert to a structure.
+%                the fields to use
+% add_version -- if true, add version field to serializable subobjects
+%                and the structure itself
+% 
 % Returns:
 % struc -- structure, containing information, fully defining the
 %          serializabe class
-if nargin == 1
-    add_version = false;
-end
 
-struc = obj.to_bare_struct(false);
+struc = to_bare_struct_(obj,false,add_version);
 if numel(obj)>1
     struc = struct('serial_name',class(obj),...
         'array_dat',struc);

--- a/herbert_core/utilities/classes/@serializable/private/to_struct_.m
+++ b/herbert_core/utilities/classes/@serializable/private/to_struct_.m
@@ -1,4 +1,4 @@
-function struc = to_struct_(obj)
+function struc = to_struct_(obj,add_version)
 % Convert serializable object into a special structure, which allow
 % serialization and recovery using static "serializable.from_struct"
 % operation.
@@ -9,6 +9,9 @@ function struc = to_struct_(obj)
 % Returns:
 % struc -- structure, containing information, fully defining the
 %          serializabe class
+if nargin == 1
+    add_version = false;
+end
 
 struc = obj.to_bare_struct(false);
 if numel(obj)>1
@@ -16,4 +19,7 @@ if numel(obj)>1
         'array_dat',struc);
 else
     struc.serial_name = class(obj);
+end
+if add_version
+    struc.version = obj.classVersion();
 end

--- a/herbert_core/utilities/classes/@serializable/serializable.m
+++ b/herbert_core/utilities/classes/@serializable/serializable.m
@@ -28,7 +28,7 @@ classdef serializable
     %     end
     %----------------------------------------------------------------------
     methods
-        function strc = to_struct(obj,store_class_version)
+        function strc = to_struct(obj)
             % Convert serializable object into a special structure, which allow
             % serialization and recovery using static "serializable.from_struct"
             % operation.
@@ -56,10 +56,7 @@ classdef serializable
             %          with all information, necessary to restore the
             %          initial object
             %
-            if nargin == 1
-                store_class_version = false;
-            end
-            strc = to_struct_(obj,store_class_version);
+            strc = to_struct_(obj);
         end
         function strc = to_bare_struct(obj,varargin)
             % Convert serializable object into a special structure, which allow
@@ -145,7 +142,7 @@ classdef serializable
             %                function, to distinguish between different
             %                stored versions of a serializable class
             %
-            S         = to_struct_(obj,true);
+            S         = to_struct_(obj);
         end
         %
         function obj = serializable()

--- a/herbert_core/utilities/classes/@serializable/serializable.m
+++ b/herbert_core/utilities/classes/@serializable/serializable.m
@@ -60,7 +60,7 @@ classdef serializable
         end
         function strc = to_bare_struct(obj,varargin)
             % Convert serializable object into a special structure, which allow
-            % serialization and recovery using "from_class_struct" operation
+            % serialization and recovery using "from_bare_struct" operation
             %
             % Uses independent properties obtained from indepFields method.
             % in assumption that the properties, returned by this method
@@ -96,10 +96,10 @@ classdef serializable
         end
         
         %------------------------------------------------------------------
-        function obj = from_class_struct(obj,inputs)
+        function obj = from_bare_struct(obj,inputs)
             % restore object or array of objects from a plain structure,
             % previously obtained by to_bare_struct operation
-            obj = from_class_struct_(obj,inputs);
+            obj = from_bare_struct_(obj,inputs);
         end
         %
         function ser_data = serialize(obj)
@@ -141,7 +141,7 @@ classdef serializable
             %                function, to distinguish between different
             %                stored versions of a serializable class
             %
-            S         = to_struct(obj);
+            S         = to_struct(obj,true);
             ver       = obj.classVersion();
             S.version = ver;
         end
@@ -160,27 +160,27 @@ classdef serializable
             % structure does not contain version or the version, stored
             % in the structure does not correspond to the current version
             %
-            % By default, this function interfaces the default from_class_struct
-            % method, but when the old strucure substantially differs from
-            % the moden structure, this method needs the specific overloading
-            % to allow loadob to recover new structure from an old structure.
+            % By default, this function interfaces the default from_bare_struct
+            % method, but when the old structure substantially differs from
+            % the modern structure, this method needs the specific overloading
+            % to allow loadobj to recover new structure from an old structure.
             %
             %if isfield(inputs,'version')
             %      do check for previous versions
             %      and appropriate code
             %end
             if isfield(inputs,'array_dat')
-                obj = obj.from_class_struct(inputs.array_dat);
+                obj = obj.from_bare_struct(inputs.array_dat);
             else
-                obj = obj.from_class_struct(inputs);
+                obj = obj.from_bare_struct(inputs);
             end
         end
         
     end
     methods (Static)
         function obj = from_struct(inputs)
-            % restore object or array of objects from a plain structure,
-            % previously obtained by to_class_struct operation.
+            % restore object or array of objects from a structure,
+            % previously obtained by to_struct operation.
             % To work with a generic structure, the structure should
             % contain fields:
             % class_name -- containing the name of the class, with empty

--- a/herbert_core/utilities/classes/@serializable/serializable.m
+++ b/herbert_core/utilities/classes/@serializable/serializable.m
@@ -28,7 +28,7 @@ classdef serializable
     %     end
     %----------------------------------------------------------------------
     methods
-        function strc = to_struct(obj)
+        function strc = to_struct(obj,store_class_version)
             % Convert serializable object into a special structure, which allow
             % serialization and recovery using static "serializable.from_struct"
             % operation.
@@ -56,7 +56,10 @@ classdef serializable
             %          with all information, necessary to restore the
             %          initial object
             %
-            strc = to_struct_(obj);
+            if nargin == 1
+                store_class_version = false;
+            end
+            strc = to_struct_(obj,store_class_version);
         end
         function strc = to_bare_struct(obj,varargin)
             % Convert serializable object into a special structure, which allow
@@ -77,6 +80,7 @@ classdef serializable
             %                   converted to bare structure. If false, or
             %                   absent, they are converted using to_struct
             %                   method
+            % 
             %
             % Returns:
             % struc -- structure, or structure array, containing the full
@@ -141,9 +145,7 @@ classdef serializable
             %                function, to distinguish between different
             %                stored versions of a serializable class
             %
-            S         = to_struct(obj,true);
-            ver       = obj.classVersion();
-            S.version = ver;
+            S         = to_struct_(obj,true);
         end
         %
         function obj = serializable()


### PR DESCRIPTION
small changes fix #415 
Roughly speaking, `serializable` method `to_struct` adds both `version` and `serial_name` fields. 
In addition to that, as earlier agreed, I have renamed `from_class_struc` method to `from_bare_struc` method

The reviewer should also look at https://github.com/pace-neutrons/Horace/issues/777, as I will probably make PR and merge it it immediately after merging this. The changes there are trivial -- just renames `from_class_struct` to `from_bare_struc`  whenever it used