### PR TITLE
Compiled workers - Herbert changes

### DIFF
--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -173,14 +173,13 @@ classdef ClusterMPI < ClusterWrapper
             external_dll_dir = fullfile(rootpath, 'DLL','external');
             if ispc()
                 [rs, rv] = system('where mpiexec');
-                if rs == 0
-                    mpi_exec = strip(rv);
-                    mpis = splitlines(mpi_exec);
-                    if numel(mpis) > 1
-                        % If multiple mpiexec on path, prefer user installed MS MPI
-                        mpi_id = [1 find(cellfun(@(x) ~isempty(strfind(x,'Microsoft')), mpis), 1)];
-                        mpi_exec = mpis{max(mpi_id)};
-                    end
+                mpis = splitlines(strip(rv));
+                % Ignore Matlab-bundled mpiexec (firewall issues)
+                mpis(cellfun(@(x) contains(x, matlabroot), mpis)) = [];
+                if rs == 0 && ~isempty(mpis)
+                    % If multiple mpiexec on path, prefer user installed MS MPI
+                    mpi_id = [1 find(cellfun(@(x) contains(x,'Microsoft'), mpis), 1)];
+                    mpi_exec = mpis{max(mpi_id)};
                 else
                     % No mpiexec on path, use pre-packaged version
                     mpi_exec = fullfile(external_dll_dir, 'mpiexec.exe');

--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -178,9 +178,8 @@ classdef ClusterMPI < ClusterWrapper
                     mpis = splitlines(mpi_exec);
                     if numel(mpis) > 1
                         % If multiple mpiexec on path, prefer user installed MS MPI
-                        mpi_id = find(cellfun(@(x) ~isempty(strfind(x,'Microsoft')), mpis), 1);
-                        if isempty(mpi_id), mpi_id = 1; end
-                        mpi_exec = mpis{mpi_id};
+                        mpi_id = [1 find(cellfun(@(x) ~isempty(strfind(x,'Microsoft')), mpis), 1)];
+                        mpi_exec = mpis{max(mpi_id)};
                     end
                 else
                     % No mpiexec on path, use pre-packaged version

--- a/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
+++ b/herbert_core/classes/MPIFramework/@ClusterMPI/ClusterMPI.m
@@ -172,9 +172,20 @@ classdef ClusterMPI < ClusterWrapper
             rootpath = fileparts(which('herbert_init'));
             external_dll_dir = fullfile(rootpath, 'DLL','external');
             if ispc()
-                % only one version of mpiexec is used now. May change in the
-                % future.
-                mpi_exec = fullfile(external_dll_dir, 'mpiexec.exe');
+                [rs, rv] = system('where mpiexec');
+                if rs == 0
+                    mpi_exec = strip(rv);
+                    mpis = splitlines(mpi_exec);
+                    if numel(mpis) > 1
+                        % If multiple mpiexec on path, prefer user installed MS MPI
+                        mpi_id = find(cellfun(@(x) ~isempty(strfind(x,'Microsoft')), mpis), 1);
+                        if isempty(mpi_id), mpi_id = 1; end
+                        mpi_exec = mpis{mpi_id};
+                    end
+                else
+                    % No mpiexec on path, use pre-packaged version
+                    mpi_exec = fullfile(external_dll_dir, 'mpiexec.exe');
+                end
             else
                 mpi_exec = fullfile(external_dll_dir, 'mpiexec');
                 

--- a/herbert_core/classes/MPIFramework/@ClusterParpoolWrapper/ClusterParpoolWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterParpoolWrapper/ClusterParpoolWrapper.m
@@ -94,6 +94,9 @@ classdef ClusterParpoolWrapper < ClusterWrapper
             end
             
             obj = init@ClusterWrapper(obj,n_workers,mess_exchange_framework,log_level);
+            assert(~obj.is_compiled_script_, ...
+                'HERBERT:ClusterParpoolWrapper:invalid_argument', ...
+                'Parpool cluster does not work with compiled workers')
             
             % delete interactive parallel cluster if any exist
             cl = gcp('nocreate');
@@ -137,11 +140,7 @@ classdef ClusterParpoolWrapper < ClusterWrapper
             % variables, but if the cluster is remote, the envriomental
             % variables transfer should be investigated
             obj.set_env();
-            if obj.is_compiled_script_
-                h_worker = @worker_v2;
-            else
-                h_worker = str2func(obj.worker_name_);
-            end
+            h_worker = str2func(obj.worker_name_);
             task = createTask(cjob,h_worker,0,{cs});
             
             obj.cluster_ = cl;

--- a/herbert_core/classes/MPIFramework/@ClusterParpoolWrapper/ClusterParpoolWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterParpoolWrapper/ClusterParpoolWrapper.m
@@ -137,7 +137,11 @@ classdef ClusterParpoolWrapper < ClusterWrapper
             % variables, but if the cluster is remote, the envriomental
             % variables transfer should be investigated
             obj.set_env();
-            h_worker = str2func(obj.worker_name_);
+            if obj.is_compiled_script_
+                h_worker = @worker_v2;
+            else
+                h_worker = str2func(obj.worker_name_);
+            end
             task = createTask(cjob,h_worker,0,{cs});
             
             obj.cluster_ = cl;

--- a/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
+++ b/herbert_core/classes/MPIFramework/@ClusterWrapper/ClusterWrapper.m
@@ -213,11 +213,9 @@ classdef ClusterWrapper
                 obj.matlab_starter_= fullfile(obj.matlab_starter_,'matlab');
             end
             if obj.is_compiled_script_
-                % TODO -- need checking and may be expansion when compiled
-                % horace ticket is executed.
-                obj.common_env_var_('HERBERT_PARALLEL_EXECUTOR')= obj.worker_name_;
+                obj.common_env_var_('HERBERT_PARALLEL_EXECUTOR') = obj.worker_name_;
             else
-                obj.common_env_var_('HERBERT_PARALLEL_EXECUTOR') =  obj.matlab_starter_;
+                obj.common_env_var_('HERBERT_PARALLEL_EXECUTOR') = obj.matlab_starter_;
             end
             % additional Matlab m-files search path to be available to
             % workers
@@ -461,12 +459,10 @@ classdef ClusterWrapper
             % Should throw PARALLEL_CONFIG:not_avalable exception
             % if the particular framework is not available.
             worker = config_store.instance.get_value('parallel_config','worker');
-            pkp = which(worker);
-            if isempty(pkp)
-                error('HERBERT:ClusterWrapper:not_available',...
-                    'Parallel worker %s is not on Matlab path. Parallel extensions are not available',...
-                    worker);
-            end
+            assert(~isempty(which(worker)) || exist(worker, 'file'), ...
+                'HERBERT:ClusterWrapper:not_available',...
+                'Parallel worker %s is not on Matlab path. Parallel extensions are not available',...
+                worker);
         end
         % The property returns the list of the configurations, available for
         % usage by the

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -215,30 +215,30 @@ classdef parallel_config<config_base
         %-----------------------------------------------------------------
         % overloaded getters
         function wrkr = get.worker(obj)
-            wrkr = get_or_restore_field(obj, 'worker');
+            wrkr = obj.get_or_restore_field('worker');
         end
         function wrkr = get.is_compiled(obj)
-            wrkr = get_or_restore_field(obj, 'is_compiled');
+            wrkr = obj.get_or_restore_field('is_compiled');
         end
         
-        function frmw =get.parallel_cluster(obj)
+        function frmw = get.parallel_cluster(obj)
             %
             wrkr = config_store.instance.get_value(obj,'worker');
             frmw = 'none';
             if ~isempty(which(wrkr)) || exist(wrkr, 'file')
-                frmw = get_or_restore_field(obj, 'parallel_cluster');
+                frmw = obj.get_or_restore_field('parallel_cluster');
             end
         end
         function conf = get.cluster_config(obj)
-            conf = get_or_restore_field(obj,'cluster_config');
+            conf = obj.get_or_restore_field('cluster_config');
         end
         %
-        function folder =get.shared_folder_on_local(obj)
-            folder = get_or_restore_field(obj,'shared_folder_on_local');
+        function folder = get.shared_folder_on_local(obj)
+            folder = obj.get_or_restore_field('shared_folder_on_local');
             if isempty(folder)
                 is_depl = MPI_State.instance().is_deployed;
                 if is_depl
-                    folder = get_or_restore_field(obj,'working_directory');
+                    folder = obj.get_or_restore_field('working_directory');
                     if isempty(folder)
                         folder = tmp_dir;
                     end
@@ -246,8 +246,8 @@ classdef parallel_config<config_base
             end
         end
         %
-        function folder =get.shared_folder_on_remote(obj)
-            folder = get_or_restore_field(obj,'shared_folder_on_remote');
+        function folder = get.shared_folder_on_remote(obj)
+            folder = obj.get_or_restore_field('shared_folder_on_remote');
             if isempty(folder)
                 folder = obj.shared_folder_on_local;
             end
@@ -258,7 +258,7 @@ classdef parallel_config<config_base
             if is_depl
                 work_dir = obj.shared_folder_on_remote;
             else
-                work_dir = get_or_restore_field(obj,'working_directory');
+                work_dir = obj.get_or_restore_field('working_directory');
             end
             if isempty(work_dir)
                 work_dir = tmp_dir;
@@ -272,7 +272,7 @@ classdef parallel_config<config_base
             if is_depl
                 work_dir = obj.shared_folder_on_remote;
             else
-                work_dir = get_or_restore_field(obj,'working_directory');
+                work_dir = obj.get_or_restore_field('working_directory');
             end
             if isempty(work_dir)
                 is = true;
@@ -408,7 +408,7 @@ classdef parallel_config<config_base
         end
         %
         function mpirunner = get.external_mpiexec(obj)
-            mpirunner  = get_or_restore_field(obj,'external_mpiexec');
+            mpirunner = obj.get_or_restore_field('external_mpiexec');
         end
         %
         function obj=set.external_mpiexec(obj,val)

--- a/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/parallel_config.m
@@ -215,22 +215,19 @@ classdef parallel_config<config_base
         %-----------------------------------------------------------------
         % overloaded getters
         function wrkr = get.worker(obj)
-            wrkr= get_or_restore_field(obj,'worker');
+            wrkr = get_or_restore_field(obj, 'worker');
         end
         function wrkr = get.is_compiled(obj)
-            % incomplete! Should be derived from worker
-            wrkr= obj.is_compiled_;
+            wrkr = get_or_restore_field(obj, 'is_compiled');
         end
         
         function frmw =get.parallel_cluster(obj)
             %
             wrkr = config_store.instance.get_value(obj,'worker');
-            pkp = which(wrkr);
-            if isempty(pkp)
-                frmw = 'none';
-                return
+            frmw = 'none';
+            if ~isempty(which(wrkr)) || exist(wrkr, 'file')
+                frmw = get_or_restore_field(obj, 'parallel_cluster');
             end
-            frmw = get_or_restore_field(obj,'parallel_cluster');
         end
         function conf = get.cluster_config(obj)
             conf = get_or_restore_field(obj,'cluster_config');

--- a/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_cluster_.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_cluster_.m
@@ -7,13 +7,11 @@ function obj = check_and_set_cluster_(obj,cluster_name)
 % The cluster name (can be defined by single symbol)
 % or by a cluster number in the list of clusters
 %
-wrkr = which(obj.worker_);
-mff = MPI_clusters_factory.instance();
+    assert(~isempty(which(obj.worker)) || exist(obj.worker, 'file'), ...
+        'HERBERT:parallel_config:not_available', ...
+        'Parallel worker is not on the Matlab path so parallel features are not available');
 
-if isempty(wrkr)
-    error('HERBERT:parallel_config:not_available',...
-        'Parallel worker is not on the Matlab path so parallel features are not available')
-else
+    mff = MPI_clusters_factory.instance();
     known_clusters = mff.known_cluster_names;
     full_cl_name = obj.select_option(known_clusters,cluster_name);
     mff.parallel_cluster = full_cl_name;

--- a/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_worker_.m
+++ b/herbert_core/classes/MPIFramework/@parallel_config/private/check_and_set_worker_.m
@@ -8,12 +8,13 @@ if ~ischar(new_wrkr)
         'The worker property needs the executable script name')
 end
 scr_path = which(new_wrkr);
+config_instance = config_store.instance();
 if isempty(scr_path)
     % Check if it is a compiled worker
-    new_wrkr = check_compiled_(new_wrkr);
-    if ~isempty(new_wrkr)
-        config_store.instance().store_config(obj, 'worker', new_wrkr);
-        config_store.instance().store_config(obj, 'is_compiled', true);
+    compiled_wrkr = check_compiled_(new_wrkr);
+    if ~isempty(compiled_wrkr)
+        config_instance.store_config(obj, 'worker', new_wrkr);
+        config_instance.store_config(obj, 'is_compiled', true);
         return
     end
 
@@ -26,12 +27,12 @@ if isempty(scr_path)
                 'to all running Matlab sessions but parallel config can not find it.',...
                 ' Parallel extensions are disabled'],...
                 new_wrkr)
-            config_store.instance().store_config(obj,...
+            config_instance.store_config(obj,...
                 'parallel_cluster','none','cluster_config','none');
             
         end
     else
-        config_store.instance().store_config(obj,'worker',def_wrkr);
+        config_instance.store_config(obj,'worker',def_wrkr);
         error('PARALLEL_CONFIG:invalid_argument',...
             ['The script to run in parallel (%s) should be available ',...
             'to all running Matlab sessions but parallel config can not find it.',...
@@ -40,18 +41,22 @@ if isempty(scr_path)
         
     end
 else % worker function is available.
-    config_store.instance().store_config(obj, 'worker', new_wrkr);
-    config_store.instance().store_config(obj, 'is_compiled', false);
+    config_instance.store_config(obj, 'worker', new_wrkr);
+    config_instance.store_config(obj, 'is_compiled', false);
 end
 end % function
 
 function out = check_compiled_(worker)
     out = '';
-    if exist(worker, 'file')
+    if is_file(worker) && ~endsWith(worker, '.m')
         % Assume if input is full path to file, then it is a compiled worker
         out = worker;
     else
-        if ispc(), cmd = 'where'; else, cmd = 'which'; end
+        if ispc()
+            cmd = 'where';
+        else
+            cmd = 'which';
+        end
         [rs, rv] = system([cmd ' ' worker]);
         if rs == 0
             % Assume if it is on the system path, then it is a compiled worker


### PR DESCRIPTION
Changes the checks in `@parallel_config` and `@MPI*` classes to allow compiled workers.

When the `worker` field of `parallel_config` is set to something which is _not_ a Matlab function, then it is checked to see if it may be a compiled worker. This check considers something a compiled worker if:

* It is a full path to a existing file; OR
* It is a command on the system `PATH` (as determined by the `which` (Linux) or `where` (Windows) command).

The full path to the file is set as the worker and the `is_compiled` flag is set to true. No check is made as to whether this file is actually executable or can run Horace etc... if it is not then any parallel computation will fail further down the chain; such checks would involve (perhaps significant) modification of `worker_v2` and/or setting up an actual computation which would take too long... we *assume* users would not set a worker they know will not work... (and if they do they will get an error when they try to run a computation...)

The actual compiled worker code is in a [Horace PR #794](https://github.com/pace-neutrons/Horace/pull/794). Tests will be added in the Horace PR (later!)